### PR TITLE
chore: ignore .changeset directory in prettier and cspell

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 pnpm-lock.yaml
+.changeset/

--- a/cspell.json
+++ b/cspell.json
@@ -8,7 +8,15 @@
   },
   "enableGlobDot": true,
   "useGitignore": true,
-  "ignorePaths": [".git", ".gitignore", "package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml", "LICENSE"],
+  "ignorePaths": [
+    ".git",
+    ".gitignore",
+    "package.json",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "LICENSE",
+    ".changeset"
+  ],
   "dictionaries": ["cspell.txt"],
   "dictionaryDefinitions": [
     {


### PR DESCRIPTION
Exclude `.changeset` directory from prettier and cspell checks.