### PR TITLE
style(ci): use single quotes in workflow files

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
     paths:
-      - "docs/**"
-      - ".github/workflows/docs.yml"
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,9 @@ jobs:
         with:
           version: pnpm changeset:version
           publish: pnpm changeset:publish
-          title: "chore(release): version packages"
-          commit: "chore(release): version packages"
-          commitMode: "github-api"
+          title: 'chore(release): version packages'
+          commit: 'chore(release): version packages'
+          commitMode: 'github-api'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Use single quotes instead of double quotes in GitHub workflow files.