### PR TITLE
refactor: simplify package.json exports to reference source files

### DIFF
--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1-next.3",
   "sideEffects": false,
   "type": "module",
-  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "files": [
     "dist",
     "package.json",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1-next.3",
   "sideEffects": false,
   "type": "module",
-  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "files": [
     "dist",
     "package.json",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1-next.3",
   "sideEffects": false,
   "type": "module",
-  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "files": [
     "dist",
     "package.json",

--- a/packages/extractor/package.json
+++ b/packages/extractor/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1-next.3",
   "sideEffects": false,
   "type": "module",
-  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "files": [
     "dist",
     "package.json",

--- a/packages/mearie/package.json
+++ b/packages/mearie/package.json
@@ -4,23 +4,10 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    },
-    "./config": {
-      "types": "./src/config.ts",
-      "import": "./src/config.ts",
-      "default": "./src/config.ts"
-    },
-    "./vite": {
-      "types": "./src/vite.ts",
-      "import": "./src/vite.ts",
-      "default": "./src/vite.ts"
-    }
+    ".": "./src/index.ts",
+    "./config": "./src/config.ts",
+    "./vite": "./src/vite.ts"
   },
-  "main": "./src/index.ts",
   "files": [
     "dist",
     "package.json",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1-next.3",
   "sideEffects": false,
   "type": "module",
-  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "files": [
     "dist",
     "package.json",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1-next.3",
   "sideEffects": false,
   "type": "module",
-  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "files": [
     "dist",
     "package.json",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1-next.3",
   "sideEffects": false,
   "type": "module",
-  "main": "./src/index.svelte.ts",
+  "exports": {
+    ".": "./src/index.svelte.ts"
+  },
   "files": [
     "dist",
     "package.json",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1-next.3",
   "sideEffects": false,
   "type": "module",
-  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "files": [
     "dist",
     "package.json",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1-next.3",
   "sideEffects": false,
   "type": "module",
-  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
   "files": [
     "dist",
     "package.json",


### PR DESCRIPTION
Replaces the `main` field with `exports` field in all packages to directly reference source files during development.

**Changes:**
- Removed `main` field from 10 packages
- Added `exports` field pointing to source files (`./src/index.ts`)
- For `mearie` package, simplified exports structure from verbose object notation to simple string paths
- `publishConfig` exports remain unchanged for production builds

This aligns with modern Node.js module resolution practices and simplifies the development experience.