### PR TITLE
refactor(examples): use mearie/vite subpath export

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,7 +10,6 @@
   },
   "devDependencies": {
     "@mearie/react": "workspace:*",
-    "@mearie/vite": "workspace:*",
     "mearie": "workspace:*",
     "vite": "^7.1.10"
   }

--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import { mearie } from '@mearie/vite';
+import mearie from 'mearie/vite';
 
 export default defineConfig({
   plugins: [mearie()],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,9 +107,6 @@ importers:
       '@mearie/react':
         specifier: workspace:*
         version: link:../../packages/react
-      '@mearie/vite':
-        specifier: workspace:*
-        version: link:../../packages/vite
       mearie:
         specifier: workspace:*
         version: link:../../packages/mearie


### PR DESCRIPTION
Removes the `@mearie/vite` dependency from the basic example and uses the `mearie/vite` subpath export instead.

This is the recommended way to import the Vite plugin since `mearie` already provides the `/vite` subpath export.