### PR TITLE
docs: add meta descriptions to documentation pages for SEO

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -160,4 +160,11 @@ export default defineConfig({
       },
     },
   },
+
+  transformHead: ({ title, description }) => {
+    return [
+      ['meta', { property: 'og:title', content: title }],
+      ['meta', { property: 'og:description', content: description }],
+    ];
+  },
 });

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+---
+description: Track all notable changes and improvements to Mearie. See version history, new features, bug fixes, and breaking changes.
+---
+
 # Changelog
 
 Track all notable changes and improvements to Mearie.

--- a/docs/config/client.md
+++ b/docs/config/client.md
@@ -1,3 +1,7 @@
+---
+description: Configure the GraphQL client with links for networking, caching, and custom behavior. Learn basic and recommended production configurations.
+---
+
 # Client Config
 
 Configure the GraphQL client with links for networking, caching, and custom behavior.

--- a/docs/config/codegen.md
+++ b/docs/config/codegen.md
@@ -1,3 +1,7 @@
+---
+description: Configure Mearie's build plugin for automatic type generation from your GraphQL schema. Learn about schema, document, exclude, and scalars options.
+---
+
 # Codegen Config
 
 Configure Mearie's build plugin for automatic type generation from your GraphQL schema.

--- a/docs/directives/required.md
+++ b/docs/directives/required.md
@@ -1,3 +1,7 @@
+---
+description: Control field nullability on the client side with the @required directive. Choose between THROW and CASCADE actions to handle null values.
+---
+
 # `@required` Directive
 
 Control field nullability on the client side.

--- a/docs/frameworks/react.md
+++ b/docs/frameworks/react.md
@@ -1,3 +1,7 @@
+---
+description: React hooks for queries, mutations, fragments, and subscriptions with full type safety and React Suspense support. Learn about useQuery, useMutation, useFragment, and useSubscription.
+---
+
 # React Integration
 
 Mearie provides React hooks for queries, mutations, fragments, and subscriptions with full type safety and React Suspense support.

--- a/docs/frameworks/solid.md
+++ b/docs/frameworks/solid.md
@@ -1,3 +1,7 @@
+---
+description: Solid primitives that leverage fine-grained reactivity for optimal performance and full type safety. Learn about createQuery, createMutation, createFragment, and createSubscription.
+---
+
 # Solid Integration
 
 Mearie provides Solid primitives that leverage fine-grained reactivity for optimal performance and full type safety.

--- a/docs/frameworks/svelte.md
+++ b/docs/frameworks/svelte.md
@@ -1,3 +1,7 @@
+---
+description: Svelte stores that work seamlessly with Svelte's fine-grained reactivity and runes for full type safety. Learn about createQuery, createMutation, createFragment, and createSubscription.
+---
+
 # Svelte Integration
 
 Mearie provides Svelte stores that work seamlessly with Svelte's fine-grained reactivity and runes for full type safety.

--- a/docs/frameworks/vue.md
+++ b/docs/frameworks/vue.md
@@ -1,3 +1,7 @@
+---
+description: Vue composables that integrate seamlessly with Vue's reactive system for automatic query refetching and full type safety. Learn about useQuery, useMutation, useFragment, and useSubscription.
+---
+
 # Vue Integration
 
 Mearie provides Vue composables that integrate seamlessly with Vue's reactive system for automatic query refetching and full type safety.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,3 +1,7 @@
+---
+description: Install Mearie and your framework integration for React, Vue, Svelte, or Solid using npm, yarn, pnpm, bun, or deno.
+---
+
 # Installation
 
 Install Mearie and your framework integration.

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -1,3 +1,7 @@
+---
+description: Configure Mearie's build plugin for automatic type generation, create a GraphQL client with links, and set up the provider for your framework.
+---
+
 # Setup
 
 Configure Mearie's build plugin, create a client, and connect it to your framework.

--- a/docs/getting-started/using-fragments.md
+++ b/docs/getting-started/using-fragments.md
@@ -1,3 +1,7 @@
+---
+description: Split complex queries into reusable fragments and colocate data requirements with components for better maintainability and type safety.
+---
+
 # Using Fragments
 
 Fragments let you split complex queries into reusable pieces and colocate data requirements with components.

--- a/docs/getting-started/your-first-query.md
+++ b/docs/getting-started/your-first-query.md
@@ -1,3 +1,7 @@
+---
+description: Write your first GraphQL query and mutation with full type safety and automatic type generation. Learn how to handle loading states and errors.
+---
+
 # Your First Query
 
 Write your first GraphQL query with full type safety.

--- a/docs/guides/directives.md
+++ b/docs/guides/directives.md
@@ -1,3 +1,7 @@
+---
+description: Customize GraphQL behavior on the client side with special directives like @required. Learn how directives work at code generation and runtime.
+---
+
 # Directives
 
 Customize GraphQL behavior on the client side with special directives.

--- a/docs/guides/fragments.md
+++ b/docs/guides/fragments.md
@@ -1,3 +1,7 @@
+---
+description: Learn how to co-locate data requirements with components using fragments. Explore fragment composition, nested fragments, and inline fragments for unions.
+---
+
 # Fragments
 
 Learn how to co-locate data requirements with components using fragments.

--- a/docs/guides/links.md
+++ b/docs/guides/links.md
@@ -1,3 +1,7 @@
+---
+description: Customize how GraphQL operations are executed with composable middleware. Learn about terminating and non-terminating links, execution order, and built-in links.
+---
+
 # Links
 
 Customize how GraphQL operations are executed with composable middleware.

--- a/docs/guides/mutations.md
+++ b/docs/guides/mutations.md
@@ -1,3 +1,7 @@
+---
+description: Learn how to modify data with GraphQL mutations, implement optimistic updates, and handle loading states with automatic cache updates.
+---
+
 # Mutations
 
 Learn how to modify data with mutations.

--- a/docs/guides/queries.md
+++ b/docs/guides/queries.md
@@ -1,3 +1,7 @@
+---
+description: Learn how to fetch data with GraphQL queries, handle loading states and errors, implement pagination, and use query options like fetch policies.
+---
+
 # Queries
 
 Learn how to fetch data with queries.

--- a/docs/guides/scalars.md
+++ b/docs/guides/scalars.md
@@ -1,3 +1,7 @@
+---
+description: Transform custom GraphQL scalars like DateTime, JSON, and UUID into native JavaScript types with automatic parsing and serialization.
+---
+
 # Scalars
 
 Transform custom GraphQL scalars into native JavaScript types automatically.

--- a/docs/guides/subscriptions.md
+++ b/docs/guides/subscriptions.md
@@ -1,3 +1,7 @@
+---
+description: Learn how to handle real-time data updates with GraphQL subscriptions using Server-Sent Events or WebSocket. Combine queries with subscriptions for initial data.
+---
+
 # Subscriptions
 
 Learn how to handle real-time data updates with subscriptions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,16 +2,9 @@
 layout: home
 
 title: Mearie - The GraphQL client that feels like magic
-titleTemplate: ':title'
+description: Zero-boilerplate GraphQL client with complete type safety and zero runtime overhead. Supports React, Vue, Svelte, and Solid with automatic code generation and intelligent caching.
 
-head:
-  - [
-      'meta',
-      {
-        property: 'og:description',
-        content: 'Zero-boilerplate GraphQL client with complete type safety and zero runtime overhead. Supports React, Vue, Svelte, and Solid with automatic code generation and intelligent caching.',
-      },
-    ]
+titleTemplate: ':title'
 
 hero:
   name: Mearie

--- a/docs/links/cache.md
+++ b/docs/links/cache.md
@@ -1,3 +1,7 @@
+---
+description: Normalized caching with automatic dependency tracking and fine-grained updates. Configure fetch policies and enable progressive enhancement.
+---
+
 # Cache Link
 
 Normalized caching with automatic dependency tracking and fine-grained updates.

--- a/docs/links/custom.md
+++ b/docs/links/custom.md
@@ -1,3 +1,7 @@
+---
+description: Create your own links to add custom behavior to GraphQL operations. Learn about logging, headers, performance monitoring, rate limiting, and error handling.
+---
+
 # Custom Links
 
 Create your own links to add custom behavior to GraphQL operations.

--- a/docs/links/dedup.md
+++ b/docs/links/dedup.md
@@ -1,3 +1,7 @@
+---
+description: Prevent duplicate concurrent requests to reduce unnecessary network traffic. Automatically deduplicates identical queries while preserving mutation safety.
+---
+
 # Deduplication Link
 
 Prevent duplicate concurrent requests, reducing unnecessary network traffic.

--- a/docs/links/http.md
+++ b/docs/links/http.md
@@ -1,3 +1,7 @@
+---
+description: Send GraphQL operations to a server over HTTP. Configure URL, headers, credentials, and request cancellation for your GraphQL endpoint.
+---
+
 # HTTP Link
 
 Send GraphQL operations to a server over HTTP.

--- a/docs/links/retry.md
+++ b/docs/links/retry.md
@@ -1,3 +1,7 @@
+---
+description: Automatically retry failed requests with exponential backoff. Configure max attempts, backoff strategy, jitter, and retry conditions for network errors.
+---
+
 # Retry Link
 
 Automatically retry failed requests with exponential backoff.

--- a/docs/links/sse.md
+++ b/docs/links/sse.md
@@ -1,3 +1,7 @@
+---
+description: Use Server-Sent Events for real-time GraphQL subscriptions. Configure URL, headers, credentials, and automatic reconnection for streaming updates.
+---
+
 # SSE Link
 
 Use Server-Sent Events for real-time GraphQL subscriptions.

--- a/docs/links/ws.md
+++ b/docs/links/ws.md
@@ -1,3 +1,7 @@
+---
+description: Use WebSocket connections for real-time GraphQL subscriptions. Configure URL, connection parameters, lazy connection, keep-alive, and automatic reconnection.
+---
+
 # WebSocket Link
 
 Use WebSocket connections for real-time GraphQL subscriptions.

--- a/docs/why-mearie.md
+++ b/docs/why-mearie.md
@@ -1,3 +1,7 @@
+---
+description: A zero-config GraphQL client with zero boilerplate, complete type safety, and zero runtime overhead. Learn why Mearie is different and see quick examples.
+---
+
 # Why Mearie?
 
 Mearie (메아리, meaning "echo" in Korean) is a zero-config GraphQL client for React, Vue, Svelte, Solid, and more.


### PR DESCRIPTION
## Overview
Add meta descriptions to all documentation pages for improved SEO and social media sharing.

## Changes
- Add `description` frontmatter field to all 28 documentation markdown files
- Configure VitePress to automatically transform descriptions into `og:description` meta tags
- Simplify `index.md` by consolidating meta description in frontmatter instead of head array
- Each page now has contextually appropriate description based on its content

## Impact
Improves documentation discoverability through search engines and enhances social media sharing experience with proper Open Graph descriptions.