### PR TITLE
chore: clean up TypeScript configurations

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "bundler"
+  },
   "include": [".vitepress/**/*", "index.d.ts"]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "outDir": "./dist",
-    "rootDir": "./src"
-  },
-  "include": ["src"]
+    "jsx": "react-jsx"
+  }
 }

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -2,9 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js",
-    "outDir": "./dist",
-    "rootDir": "./src"
-  },
-  "include": ["src"]
+    "jsxImportSource": "solid-js"
+  }
 }

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
-  },
-  "include": ["src"]
-}

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
-  },
-  "include": ["src"]
-}


### PR DESCRIPTION
## Summary
- Remove redundant compiler options from package-level tsconfig.json files
- Add moduleResolution bundler to docs tsconfig
- Remove unused tsconfig files for svelte and vue packages

## Changes
- **docs/tsconfig.json**: Added `moduleResolution: "bundler"`
- **packages/react/tsconfig.json**: Removed `outDir`, `rootDir`, and `include` (inherited from root)
- **packages/solid/tsconfig.json**: Removed `outDir`, `rootDir`, and `include` (inherited from root)
- **packages/svelte/tsconfig.json**: Deleted (package not in use)
- **packages/vue/tsconfig.json**: Deleted (package not in use)

These configurations are already defined in the root tsconfig.json, so they don't need to be duplicated.