### PR TITLE
fix(docs): remove incompatible moduleResolution setting

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "moduleResolution": "bundler"
-  },
   "include": ["ambient.d.ts"]
 }


### PR DESCRIPTION
## Summary
- Removed `moduleResolution: "bundler"` from `docs/tsconfig.json` that was incompatible with inherited `module: "nodenext"` setting
- Fixes TypeScript diagnostics errors: `moduleResolution` must be set to 'NodeNext' when `module` is 'NodeNext'

## Test plan
- [x] Verify no TypeScript diagnostic errors in docs directory
- [ ] Confirm documentation builds successfully