### PR TITLE
chore(react,solid,svelte,vue): simplify build configs and update dependencies

### DIFF
--- a/.changeset/calm-trees-dance.md
+++ b/.changeset/calm-trees-dance.md
@@ -1,0 +1,8 @@
+---
+"@mearie/react": patch
+"@mearie/solid": patch
+"@mearie/svelte": patch
+"@mearie/vue": patch
+---
+
+Update framework binding packages to use core package directly and simplify build configurations

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "outDir": "./dist",
-    "rootDir": "./src"
-  },
-  "include": ["src"]
+    "jsx": "react-jsx"
+  }
 }

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -12,11 +12,10 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch"
+    "build": "tsdown"
   },
   "dependencies": {
-    "@mearie/client": "workspace:*"
+    "@mearie/core": "workspace:*"
   },
   "devDependencies": {
     "solid-js": "^1.9.9",

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -2,9 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js",
-    "outDir": "./dist",
-    "rootDir": "./src"
-  },
-  "include": ["src"]
+    "jsxImportSource": "solid-js"
+  }
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -12,11 +12,10 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch"
+    "build": "tsdown"
   },
   "dependencies": {
-    "@mearie/client": "workspace:*"
+    "@mearie/core": "workspace:*"
   },
   "devDependencies": {
     "svelte": "^5.41.0",

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
-  },
-  "include": ["src"]
-}

--- a/packages/svelte/tsdown.config.ts
+++ b/packages/svelte/tsdown.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   clean: true,
   dts: true,
-  external: ['svelte', 'svelte/store'],
+  external: ['svelte'],
 });

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -12,11 +12,10 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsdown",
-    "dev": "tsdown --watch"
+    "build": "tsdown"
   },
   "dependencies": {
-    "@mearie/client": "workspace:*"
+    "@mearie/core": "workspace:*"
   },
   "devDependencies": {
     "tsdown": "catalog:",

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
-  },
-  "include": ["src"]
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,9 +260,9 @@ importers:
 
   packages/solid:
     dependencies:
-      '@mearie/client':
+      '@mearie/core':
         specifier: workspace:*
-        version: link:../client
+        version: link:../core
     devDependencies:
       solid-js:
         specifier: ^1.9.9
@@ -273,9 +273,9 @@ importers:
 
   packages/svelte:
     dependencies:
-      '@mearie/client':
+      '@mearie/core':
         specifier: workspace:*
-        version: link:../client
+        version: link:../core
     devDependencies:
       svelte:
         specifier: ^5.41.0
@@ -311,9 +311,9 @@ importers:
 
   packages/vue:
     dependencies:
-      '@mearie/client':
+      '@mearie/core':
         specifier: workspace:*
-        version: link:../client
+        version: link:../core
     devDependencies:
       tsdown:
         specifier: 'catalog:'


### PR DESCRIPTION
## Overview
Simplify build configurations and update dependencies for framework binding packages

## Changes
- Simplify TypeScript configurations by removing redundant `outDir`, `rootDir`, and `include` options
- Update framework bindings to depend on `@mearie/core` instead of `@mearie/client`
- Remove `dev` scripts from package.json files (keep `build` only)
- Remove unnecessary `tsconfig.json` from svelte package
- Clean up external dependencies in svelte build config

## Impact
This change standardizes build configurations across framework binding packages and ensures they use the core package directly for better maintainability.