### PR TITLE
ci(release): use git commit mode in changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,8 @@ jobs:
         with:
           version: pnpm changeset:version
           publish: pnpm changeset:publish
-          title: 'chore(release): version packages'
-          commit: 'chore(release): version packages'
-          commitMode: 'github-api'
+          title: "chore(release): version packages"
+          commit: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

Fix the issue where changesets action repeatedly closes and reopens the release PR whenever a new commit is pushed to main.

## Changes

- Remove `commitMode: 'github-api'` from the changesets action configuration
- Change quotes from single to double quotes for consistency

## Impact

The release PR (#10) will no longer be closed and reopened on every main branch update. Instead, it will be smoothly updated in place using git commits.

## Related

- Fixes the behavior observed in #10 where the PR was closed/reopened multiple times