### PR TITLE
docs: update package structure and import paths

### DIFF
--- a/docs/ambient.d.ts
+++ b/docs/ambient.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@mearie/client" />

--- a/docs/config/client.md
+++ b/docs/config/client.md
@@ -12,7 +12,7 @@ Create a client with at least one terminating link (like `httpLink`):
 
 ```typescript
 // src/lib/graphql-client.ts
-import { createClient, httpLink } from 'mearie';
+import { createClient, httpLink } from '@mearie/react'; // or @mearie/vue, @mearie/svelte, @mearie/solid
 
 export const client = createClient({
   links: [
@@ -28,7 +28,7 @@ export const client = createClient({
 Add caching and deduplication for production use:
 
 ```typescript
-import { createClient, httpLink, cacheLink, dedupLink } from 'mearie';
+import { createClient, httpLink, cacheLink, dedupLink } from '@mearie/react'; // or @mearie/vue, @mearie/svelte, @mearie/solid
 
 export const client = createClient({
   links: [

--- a/docs/env.d.ts
+++ b/docs/env.d.ts
@@ -1,0 +1,1 @@
+import './.mearie/graphql.d.ts';

--- a/docs/frameworks/react.md
+++ b/docs/frameworks/react.md
@@ -13,23 +13,28 @@ Install the core package and the React integration:
 ::: code-group
 
 ```sh [npm]
-npm install mearie @mearie/react
+npm install -D mearie
+npm install @mearie/react
 ```
 
 ```sh [yarn]
-yarn add mearie @mearie/react
+yarn add -D mearie
+yarn add @mearie/react
 ```
 
 ```sh [pnpm]
-pnpm add mearie @mearie/react
+pnpm add -D mearie
+pnpm add @mearie/react
 ```
 
 ```sh [bun]
-bun add mearie @mearie/react
+bun add -D mearie
+bun add @mearie/react
 ```
 
 ```sh [deno]
-deno add npm:mearie npm:@mearie/react
+deno add --dev npm:mearie
+deno add npm:@mearie/react
 ```
 
 :::
@@ -70,11 +75,11 @@ By default, Mearie looks for `./schema.graphql` relative to your `vite.config.ts
 
 ### 2. Create Client
 
-Create a GraphQL client with your API endpoint. Links are middleware-style handlers that process requests and responses. At least one terminating link is required (in this case, `httpLink`). See [Links](/guides/links) for more details.
+Create a GraphQL client with your API endpoint. Import `createClient` and links from `@mearie/react`:
 
 ```typescript
 // src/lib/graphql-client.ts
-import { createClient, httpLink, cacheLink, dedupLink } from 'mearie';
+import { createClient, httpLink, cacheLink, dedupLink } from '@mearie/react';
 
 export const client = createClient({
   links: [
@@ -86,6 +91,8 @@ export const client = createClient({
   ],
 });
 ```
+
+See [Links](/guides/links) for more details on available links and middleware.
 
 ### 3. Set Up Provider
 
@@ -108,7 +115,7 @@ import { client } from './lib/graphql-client';
 Fetch data with automatic caching and updates:
 
 ```tsx
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/react';
 
 export const UserProfile = ({ userId }: { userId: string }) => {
@@ -152,7 +159,7 @@ Modify data with automatic cache updates:
 
 ```tsx
 import { useState } from 'react';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useMutation } from '@mearie/react';
 
 export const EditUserForm = ({ userId }: { userId: string }) => {
@@ -189,9 +196,9 @@ export const EditUserForm = ({ userId }: { userId: string }) => {
 Co-locate data requirements with components:
 
 ```tsx
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useFragment } from '@mearie/react';
-import type { UserCard_user$key } from 'mearie/types';
+import type { UserCard_user$key } from '~graphql';
 
 export const UserCard = ({ user }: { user: UserCard_user$key }) => {
   const data = useFragment(
@@ -221,7 +228,7 @@ export const UserCard = ({ user }: { user: UserCard_user$key }) => {
 Real-time updates via subscriptions:
 
 ```tsx
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useSubscription } from '@mearie/react';
 
 interface ChatMessagesProps {
@@ -266,7 +273,7 @@ Use with React Suspense for simpler loading states:
 
 ```tsx
 import { Suspense } from 'react';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/react';
 
 const UserProfile = ({ userId }: { userId: string }) => {

--- a/docs/frameworks/solid.md
+++ b/docs/frameworks/solid.md
@@ -13,23 +13,28 @@ Install the core package and the Solid integration:
 ::: code-group
 
 ```sh [npm]
-npm install mearie @mearie/solid
+npm install -D mearie
+npm install @mearie/solid
 ```
 
 ```sh [yarn]
-yarn add mearie @mearie/solid
+yarn add -D mearie
+yarn add @mearie/solid
 ```
 
 ```sh [pnpm]
-pnpm add mearie @mearie/solid
+pnpm add -D mearie
+pnpm add @mearie/solid
 ```
 
 ```sh [bun]
-bun add mearie @mearie/solid
+bun add -D mearie
+bun add @mearie/solid
 ```
 
 ```sh [deno]
-deno add npm:mearie npm:@mearie/solid
+deno add --dev npm:mearie
+deno add npm:@mearie/solid
 ```
 
 :::
@@ -57,11 +62,11 @@ By default, Mearie looks for `./schema.graphql` relative to your `vite.config.ts
 
 ### 2. Create Client
 
-Create a GraphQL client with your API endpoint. Links are middleware-style handlers that process requests and responses. At least one terminating link is required (in this case, `httpLink`). See [Links](/guides/links) for more details.
+Create a GraphQL client with your API endpoint. Import `createClient` and links from `@mearie/solid`:
 
 ```typescript
 // src/lib/graphql-client.ts
-import { createClient, httpLink, cacheLink, dedupLink } from 'mearie';
+import { createClient, httpLink, cacheLink, dedupLink } from '@mearie/solid';
 
 export const client = createClient({
   links: [
@@ -73,6 +78,8 @@ export const client = createClient({
   ],
 });
 ```
+
+See [Links](/guides/links) for more details on available links and middleware.
 
 ### 3. Set Up Provider
 
@@ -96,7 +103,7 @@ Fetch data with fine-grained reactivity:
 
 ```tsx
 import { type Component } from 'solid-js';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createQuery } from '@mearie/solid';
 
 interface UserProfileProps {
@@ -144,7 +151,7 @@ Modify data with automatic cache updates:
 
 ```tsx
 import { type Component, createSignal } from 'solid-js';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createMutation } from '@mearie/solid';
 
 interface EditUserFormProps {
@@ -186,9 +193,9 @@ Co-locate data requirements with components:
 
 ```tsx
 import { type Component } from 'solid-js';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createFragment } from '@mearie/solid';
-import type { UserCard_user$key } from 'mearie/types';
+import type { UserCard_user$key } from '~graphql';
 
 interface UserCardProps {
   user: UserCard_user$key;
@@ -223,7 +230,7 @@ Real-time updates via subscriptions:
 
 ```tsx
 import { type Component } from 'solid-js';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createSubscription } from '@mearie/solid';
 
 interface ChatMessagesProps {
@@ -266,7 +273,7 @@ Solid's fine-grained reactivity works seamlessly with Mearie:
 
 ```tsx
 import { type Component } from 'solid-js';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createQuery } from '@mearie/solid';
 
 interface UserProfileProps {

--- a/docs/frameworks/svelte.md
+++ b/docs/frameworks/svelte.md
@@ -13,23 +13,28 @@ Install the core package and the Svelte integration:
 ::: code-group
 
 ```sh [npm]
-npm install mearie @mearie/svelte
+npm install -D mearie
+npm install @mearie/svelte
 ```
 
 ```sh [yarn]
-yarn add mearie @mearie/svelte
+yarn add -D mearie
+yarn add @mearie/svelte
 ```
 
 ```sh [pnpm]
-pnpm add mearie @mearie/svelte
+pnpm add -D mearie
+pnpm add @mearie/svelte
 ```
 
 ```sh [bun]
-bun add mearie @mearie/svelte
+bun add -D mearie
+bun add @mearie/svelte
 ```
 
 ```sh [deno]
-deno add npm:mearie npm:@mearie/svelte
+deno add --dev npm:mearie
+deno add npm:@mearie/svelte
 ```
 
 :::
@@ -57,11 +62,11 @@ By default, Mearie looks for `./schema.graphql` relative to your `vite.config.ts
 
 ### 2. Create Client
 
-Create a GraphQL client with your API endpoint. Links are middleware-style handlers that process requests and responses. At least one terminating link is required (in this case, `httpLink`). See [Links](/guides/links) for more details.
+Create a GraphQL client with your API endpoint. Import `createClient` and links from `@mearie/svelte`:
 
 ```typescript
 // src/lib/graphql-client.ts
-import { createClient, httpLink, cacheLink, dedupLink } from 'mearie';
+import { createClient, httpLink, cacheLink, dedupLink } from '@mearie/svelte';
 
 export const client = createClient({
   links: [
@@ -73,6 +78,8 @@ export const client = createClient({
   ],
 });
 ```
+
+See [Links](/guides/links) for more details on available links and middleware.
 
 ### 3. Set Up Provider
 
@@ -96,7 +103,7 @@ Fetch data with automatic caching:
 
 ```svelte
 <script lang="ts">
-import { graphql } from 'mearie'
+import { graphql } from '~graphql'
 import { createQuery } from '@mearie/svelte'
 
 interface Props {
@@ -146,7 +153,7 @@ Modify data with automatic cache updates:
 
 ```svelte
 <script lang="ts">
-import { graphql } from 'mearie'
+import { graphql } from '~graphql'
 import { createMutation } from '@mearie/svelte'
 
 interface Props {
@@ -187,9 +194,9 @@ Co-locate data requirements with components:
 
 ```svelte
 <script lang="ts">
-import { graphql } from 'mearie'
+import { graphql } from '~graphql'
 import { createFragment } from '@mearie/svelte'
-import type { UserCard_user$key } from 'mearie/types'
+import type { UserCard_user$key } from '~graphql'
 
 interface Props {
   user: UserCard_user$key;
@@ -223,7 +230,7 @@ Real-time updates via subscriptions:
 
 ```svelte
 <script lang="ts">
-import { graphql } from 'mearie'
+import { graphql } from '~graphql'
 import { createSubscription } from '@mearie/svelte'
 
 interface Props {
@@ -265,7 +272,7 @@ Svelte's fine-grained reactivity with runes works seamlessly with Mearie:
 
 ```svelte
 <script lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createQuery } from '@mearie/svelte';
 
 let userId = $state('123');

--- a/docs/frameworks/vue.md
+++ b/docs/frameworks/vue.md
@@ -13,23 +13,28 @@ Install the core package and the Vue integration:
 ::: code-group
 
 ```sh [npm]
-npm install mearie @mearie/vue
+npm install -D mearie
+npm install @mearie/vue
 ```
 
 ```sh [yarn]
-yarn add mearie @mearie/vue
+yarn add -D mearie
+yarn add @mearie/vue
 ```
 
 ```sh [pnpm]
-pnpm add mearie @mearie/vue
+pnpm add -D mearie
+pnpm add @mearie/vue
 ```
 
 ```sh [bun]
-bun add mearie @mearie/vue
+bun add -D mearie
+bun add @mearie/vue
 ```
 
 ```sh [deno]
-deno add npm:mearie npm:@mearie/vue
+deno add --dev npm:mearie
+deno add npm:@mearie/vue
 ```
 
 :::
@@ -57,11 +62,11 @@ By default, Mearie looks for `./schema.graphql` relative to your `vite.config.ts
 
 ### 2. Create Client
 
-Create a GraphQL client with your API endpoint. Links are middleware-style handlers that process requests and responses. At least one terminating link is required (in this case, `httpLink`). See [Links](/guides/links) for more details.
+Create a GraphQL client with your API endpoint. Import `createClient` and links from `@mearie/vue`:
 
 ```typescript
 // src/lib/graphql-client.ts
-import { createClient, httpLink, cacheLink, dedupLink } from 'mearie';
+import { createClient, httpLink, cacheLink, dedupLink } from '@mearie/vue';
 
 export const client = createClient({
   links: [
@@ -73,6 +78,8 @@ export const client = createClient({
   ],
 });
 ```
+
+See [Links](/guides/links) for more details on available links and middleware.
 
 ### 3. Set Up Provider
 
@@ -94,7 +101,7 @@ Fetch data with automatic caching:
 
 ```vue
 <script setup lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/vue';
 
 const props = defineProps<{ userId: string }>();
@@ -137,7 +144,7 @@ Modify data with automatic cache updates:
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useMutation } from '@mearie/vue';
 
 const props = defineProps<{ userId: string }>();
@@ -173,9 +180,9 @@ Co-locate data requirements with components:
 
 ```vue
 <script setup lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useFragment } from '@mearie/vue';
-import type { UserCard_user$key } from 'mearie/types';
+import type { UserCard_user$key } from '~graphql';
 
 const props = defineProps<{ user: UserCard_user$key }>();
 
@@ -207,7 +214,7 @@ Real-time updates via subscriptions:
 
 ```vue
 <script setup lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useSubscription } from '@mearie/vue';
 
 const props = defineProps<{ chatId: string }>();
@@ -246,7 +253,7 @@ Variables automatically track Vue reactivity:
 ```vue
 <script setup lang="ts">
 import { ref, computed } from 'vue';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/vue';
 
 const userId = ref('123');

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,81 +10,101 @@ Install Mearie and your framework integration.
 
 Mearie consists of two packages:
 
-- `mearie` - The core GraphQL client
-- `@mearie/{framework}` - Framework-specific bindings
+- `mearie` - Build tools and codegen (dev dependency)
+- `@mearie/{framework}` - Framework-specific bindings (includes client and runtime)
 
-Install the core package and your framework integration:
+Install the build tools as dev dependency and your framework integration:
 
 ::: code-group
 
 ```sh [npm]
 # React
-npm install mearie @mearie/react
+npm install -D mearie
+npm install @mearie/react
 
 # Vue
-npm install mearie @mearie/vue
+npm install -D mearie
+npm install @mearie/vue
 
 # Svelte
-npm install mearie @mearie/svelte
+npm install -D mearie
+npm install @mearie/svelte
 
 # Solid
-npm install mearie @mearie/solid
+npm install -D mearie
+npm install @mearie/solid
 ```
 
 ```sh [yarn]
 # React
-yarn add mearie @mearie/react
+yarn add -D mearie
+yarn add @mearie/react
 
 # Vue
-yarn add mearie @mearie/vue
+yarn add -D mearie
+yarn add @mearie/vue
 
 # Svelte
-yarn add mearie @mearie/svelte
+yarn add -D mearie
+yarn add @mearie/svelte
 
 # Solid
-yarn add mearie @mearie/solid
+yarn add -D mearie
+yarn add @mearie/solid
 ```
 
 ```sh [pnpm]
 # React
-pnpm add mearie @mearie/react
+pnpm add -D mearie
+pnpm add @mearie/react
 
 # Vue
-pnpm add mearie @mearie/vue
+pnpm add -D mearie
+pnpm add @mearie/vue
 
 # Svelte
-pnpm add mearie @mearie/svelte
+pnpm add -D mearie
+pnpm add @mearie/svelte
 
 # Solid
-pnpm add mearie @mearie/solid
+pnpm add -D mearie
+pnpm add @mearie/solid
 ```
 
 ```sh [bun]
 # React
-bun add mearie @mearie/react
+bun add -D mearie
+bun add @mearie/react
 
 # Vue
-bun add mearie @mearie/vue
+bun add -D mearie
+bun add @mearie/vue
 
 # Svelte
-bun add mearie @mearie/svelte
+bun add -D mearie
+bun add @mearie/svelte
 
 # Solid
-bun add mearie @mearie/solid
+bun add -D mearie
+bun add @mearie/solid
 ```
 
 ```sh [deno]
 # React
-deno add npm:mearie npm:@mearie/react
+deno add --dev npm:mearie
+deno add npm:@mearie/react
 
 # Vue
-deno add npm:mearie npm:@mearie/vue
+deno add --dev npm:mearie
+deno add npm:@mearie/vue
 
 # Svelte
-deno add npm:mearie npm:@mearie/svelte
+deno add --dev npm:mearie
+deno add npm:@mearie/svelte
 
 # Solid
-deno add npm:mearie npm:@mearie/solid
+deno add --dev npm:mearie
+deno add npm:@mearie/solid
 ```
 
 :::

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -38,13 +38,37 @@ export default withMearie({
 By default, Mearie looks for `./schema.graphql` relative to your `vite.config.ts` or `next.config.js`. For custom schema locations or advanced configuration, see [Codegen Config](/config/codegen).
 :::
 
+## Add Type Reference
+
+Add the generated types to your TypeScript configuration:
+
+::: code-group
+
+```typescript [env.d.ts]
+/// <reference types="vite/client" />
+
+import '../.mearie/graphql.d.ts';
+```
+
+```typescript [src/vite-env.d.ts]
+/// <reference types="vite/client" />
+
+import '../.mearie/graphql.d.ts';
+```
+
+:::
+
+This imports the auto-generated GraphQL types so TypeScript can provide type safety for your queries and mutations.
+
 ## Create Client
 
-Create a GraphQL client with your API endpoint. Links are middleware-style handlers that process requests and responses. At least one terminating link is required (in this case, `httpLink`). See [Links](/guides/links) for more details.
+Create a GraphQL client with your API endpoint. Import `createClient` and links from your framework package:
 
-```typescript
+::: code-group
+
+```typescript [React]
 // src/lib/graphql-client.ts
-import { createClient, httpLink, cacheLink, dedupLink } from 'mearie';
+import { createClient, httpLink, cacheLink, dedupLink } from '@mearie/react';
 
 export const client = createClient({
   links: [
@@ -56,6 +80,55 @@ export const client = createClient({
   ],
 });
 ```
+
+```typescript [Vue]
+// src/lib/graphql-client.ts
+import { createClient, httpLink, cacheLink, dedupLink } from '@mearie/vue';
+
+export const client = createClient({
+  links: [
+    dedupLink(),
+    cacheLink(),
+    httpLink({
+      url: 'https://api.example.com/graphql',
+    }),
+  ],
+});
+```
+
+```typescript [Svelte]
+// src/lib/graphql-client.ts
+import { createClient, httpLink, cacheLink, dedupLink } from '@mearie/svelte';
+
+export const client = createClient({
+  links: [
+    dedupLink(),
+    cacheLink(),
+    httpLink({
+      url: 'https://api.example.com/graphql',
+    }),
+  ],
+});
+```
+
+```typescript [Solid]
+// src/lib/graphql-client.ts
+import { createClient, httpLink, cacheLink, dedupLink } from '@mearie/solid';
+
+export const client = createClient({
+  links: [
+    dedupLink(),
+    cacheLink(),
+    httpLink({
+      url: 'https://api.example.com/graphql',
+    }),
+  ],
+});
+```
+
+:::
+
+See [Links](/guides/links) for more details on available links and middleware.
 
 ## Set Up Provider
 

--- a/docs/getting-started/using-fragments.md
+++ b/docs/getting-started/using-fragments.md
@@ -30,9 +30,9 @@ Define a fragment with your component:
 
 ```tsx [React]
 // src/components/UserCard.tsx
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useFragment } from '@mearie/react';
-import type { UserCard_user$key } from 'mearie/types';
+import type { UserCard_user$key } from '~graphql';
 
 export const UserCard = ({ user }: { user: UserCard_user$key }) => {
   const data = useFragment(
@@ -60,9 +60,9 @@ export const UserCard = ({ user }: { user: UserCard_user$key }) => {
 ```vue [Vue]
 <!-- src/components/UserCard.vue -->
 <script setup lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useFragment } from '@mearie/vue';
-import type { UserCard_user$key } from 'mearie/types';
+import type { UserCard_user$key } from '~graphql';
 
 const props = defineProps<{ user: UserCard_user$key }>();
 
@@ -91,9 +91,9 @@ const data = useFragment(
 ```svelte [Svelte]
 <!-- src/components/UserCard.svelte -->
 <script lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createFragment } from '@mearie/svelte';
-import type { UserCard_user$key } from 'mearie/types';
+import type { UserCard_user$key } from '~graphql';
 
 interface Props {
   user: UserCard_user$key;
@@ -124,9 +124,9 @@ const data = createFragment(
 ```tsx [Solid]
 // src/components/UserCard.tsx
 import { type Component } from 'solid-js';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createFragment } from '@mearie/solid';
-import type { UserCard_user$key } from 'mearie/types';
+import type { UserCard_user$key } from '~graphql';
 
 interface UserCardProps {
   user: UserCard_user$key;
@@ -167,7 +167,7 @@ Use the fragment in your query:
 
 ```tsx [React]
 // src/pages/UserProfile.tsx
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/react';
 import { UserCard } from '../components/UserCard';
 
@@ -190,7 +190,7 @@ export const UserProfile = ({ userId }: { userId: string }) => {
 ```vue [Vue]
 <!-- src/pages/UserProfile.vue -->
 <script setup lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/vue';
 import UserCard from '../components/UserCard.vue';
 
@@ -216,7 +216,7 @@ const { data } = useQuery(
 ```svelte [Svelte]
 <!-- src/pages/UserProfile.svelte -->
 <script lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createQuery } from '@mearie/svelte';
 import UserCard from '../components/UserCard.svelte';
 
@@ -244,7 +244,7 @@ const query = createQuery(
 ```tsx [Solid]
 // src/pages/UserProfile.tsx
 import { type Component } from 'solid-js';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createQuery } from '@mearie/solid';
 import { UserCard } from '../components/UserCard';
 

--- a/docs/getting-started/your-first-query.md
+++ b/docs/getting-started/your-first-query.md
@@ -19,7 +19,7 @@ The `graphql` function requires template literals (backticks) for build-time typ
 <!-- prettier-ignore-start -->
 ```tsx twoslash mearie [React]
 // src/components/UserProfile.tsx
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/react';
 
 interface UserProfileProps {
@@ -68,7 +68,7 @@ export const UserProfile = ({ userId }: UserProfileProps) => {
 ```vue [Vue]
 <!-- src/components/UserProfile.vue -->
 <script setup lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/vue';
 
 const props = defineProps<{ userId: string }>();
@@ -106,7 +106,7 @@ const { data, loading, error } = useQuery(
 ```svelte [Svelte]
 <!-- src/components/UserProfile.svelte -->
 <script lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createQuery } from '@mearie/svelte';
 
 interface Props {
@@ -152,7 +152,7 @@ const query = createQuery(
 ```tsx [Solid]
 // src/components/UserProfile.tsx
 import { type Component } from 'solid-js';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createQuery } from '@mearie/solid';
 
 interface UserProfileProps {
@@ -203,7 +203,7 @@ Write a mutation directly in your component:
 
 ```tsx twoslash mearie [React]
 import { useState } from 'react';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useMutation } from '@mearie/react';
 
 interface EditUserFormProps {
@@ -242,7 +242,7 @@ export const EditUserForm = ({ userId }: EditUserFormProps) => {
 ```vue [Vue]
 <script setup lang="ts">
 import { ref } from 'vue';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useMutation } from '@mearie/vue';
 
 const props = defineProps<{ userId: string }>();
@@ -274,7 +274,7 @@ const handleSubmit = async () => {
 
 ```svelte [Svelte]
 <script lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createMutation } from '@mearie/svelte';
 
 interface Props {
@@ -311,7 +311,7 @@ const handleSubmit = async (e: SubmitEvent) => {
 
 ```tsx [Solid]
 import { type Component, createSignal } from 'solid-js';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createMutation } from '@mearie/solid';
 
 interface EditUserFormProps {

--- a/docs/guides/fragments.md
+++ b/docs/guides/fragments.md
@@ -102,9 +102,9 @@ See [Vue](/frameworks/vue), [Svelte](/frameworks/svelte), or [Solid](/frameworks
 Define a fragment with your component:
 
 ```typescript
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useFragment } from '@mearie/react';
-import type { UserCard_user$key } from 'mearie/types';
+import type { UserCard_user$key } from '~graphql';
 
 export const UserCard = ({ user }: { user: UserCard_user$key }) => {
   const data = useFragment(
@@ -132,7 +132,7 @@ export const UserCard = ({ user }: { user: UserCard_user$key }) => {
 Spread the fragment in your query:
 
 ```typescript
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/react';
 import { UserCard } from './UserCard';
 

--- a/docs/guides/links.md
+++ b/docs/guides/links.md
@@ -13,7 +13,7 @@ Links are composable middleware that process your GraphQL operations. Each link 
 ## Basic Usage
 
 ```typescript
-import { createClient, httpLink, cacheLink } from 'mearie';
+import { createClient, httpLink, cacheLink } from '@mearie/react'; // or @mearie/vue, @mearie/svelte, @mearie/solid
 
 export const client = createClient({
   links: [cacheLink(), httpLink({ url: 'https://api.example.com/graphql' })],

--- a/docs/guides/mutations.md
+++ b/docs/guides/mutations.md
@@ -10,7 +10,7 @@ Learn how to modify data with mutations.
 
 ```tsx
 import { useState } from 'react';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useMutation } from '@mearie/react';
 
 export const EditUserForm = ({ userId }: { userId: string }) => {

--- a/docs/guides/queries.md
+++ b/docs/guides/queries.md
@@ -9,7 +9,7 @@ Learn how to fetch data with queries.
 ## Basic Query
 
 ```tsx
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/react';
 
 export const UserProfile = ({ userId }: { userId: string }) => {
@@ -109,7 +109,7 @@ await refetch();
 Execute queries imperatively:
 
 ```typescript
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { client } from './lib/graphql-client';
 
 const searchUsers = async (term: string) => {

--- a/docs/guides/subscriptions.md
+++ b/docs/guides/subscriptions.md
@@ -13,7 +13,7 @@ Subscriptions enable real-time communication between client and server for chat 
 Define a subscription like queries and mutations:
 
 ```typescript
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useSubscription } from '@mearie/react';
 
 const ChatMessages = ({ chatId }: { chatId: string }) => {
@@ -57,7 +57,7 @@ Configure your client to support subscriptions.
 Simple HTTP-based protocol. Recommended for most use cases.
 
 ```typescript
-import { createClient, httpLink, sseLink } from 'mearie';
+import { createClient, httpLink, sseLink } from '@mearie/react'; // or @mearie/vue, @mearie/svelte, @mearie/solid
 
 export const client = createClient({
   links: [
@@ -72,7 +72,7 @@ export const client = createClient({
 Alternative protocol with lower latency.
 
 ```typescript
-import { createClient, httpLink, wsLink } from 'mearie';
+import { createClient, httpLink, wsLink } from '@mearie/react'; // or @mearie/vue, @mearie/svelte, @mearie/solid
 
 export const client = createClient({
   links: [httpLink({ url: 'https://api.example.com/graphql' }), wsLink({ url: 'wss://api.example.com/graphql' })],

--- a/docs/links/cache.md
+++ b/docs/links/cache.md
@@ -9,7 +9,7 @@ Normalized caching with automatic dependency tracking and fine-grained updates.
 ## Basic Usage
 
 ```typescript
-import { createClient, cacheLink, httpLink } from 'mearie';
+import { createClient, cacheLink, httpLink } from '@mearie/react'; // or @mearie/vue, @mearie/svelte, @mearie/solid
 
 export const client = createClient({
   links: [cacheLink(), httpLink({ url: 'https://api.example.com/graphql' })],

--- a/docs/links/dedup.md
+++ b/docs/links/dedup.md
@@ -9,7 +9,7 @@ Prevent duplicate concurrent requests, reducing unnecessary network traffic.
 ## Basic Usage
 
 ```typescript
-import { createClient, dedupLink, httpLink } from 'mearie';
+import { createClient, dedupLink, httpLink } from '@mearie/react'; // or @mearie/vue, @mearie/svelte, @mearie/solid
 
 export const client = createClient({
   links: [dedupLink(), httpLink({ url: 'https://api.example.com/graphql' })],

--- a/docs/links/http.md
+++ b/docs/links/http.md
@@ -9,7 +9,7 @@ Send GraphQL operations to a server over HTTP.
 ## Basic Usage
 
 ```typescript
-import { createClient, httpLink } from 'mearie';
+import { createClient, httpLink } from '@mearie/react'; // or @mearie/vue, @mearie/svelte, @mearie/solid
 
 export const client = createClient({
   links: [httpLink({ url: 'https://api.example.com/graphql' })],

--- a/docs/links/retry.md
+++ b/docs/links/retry.md
@@ -9,7 +9,7 @@ Automatically retry failed requests with exponential backoff.
 ## Basic Usage
 
 ```typescript
-import { createClient, retryLink, httpLink } from 'mearie';
+import { createClient, retryLink, httpLink } from '@mearie/react'; // or @mearie/vue, @mearie/svelte, @mearie/solid
 
 export const client = createClient({
   links: [retryLink(), httpLink({ url: 'https://api.example.com/graphql' })],

--- a/docs/links/sse.md
+++ b/docs/links/sse.md
@@ -9,7 +9,7 @@ Use Server-Sent Events for real-time GraphQL subscriptions.
 ## Basic Usage
 
 ```typescript
-import { createClient, sseLink } from 'mearie';
+import { createClient, sseLink } from '@mearie/react'; // or @mearie/vue, @mearie/svelte, @mearie/solid
 
 export const client = createClient({
   links: [sseLink({ url: 'https://api.example.com/graphql' })],

--- a/docs/links/ws.md
+++ b/docs/links/ws.md
@@ -9,7 +9,7 @@ Use WebSocket connections for real-time GraphQL subscriptions.
 ## Basic Usage
 
 ```typescript
-import { createClient, wsLink } from 'mearie';
+import { createClient, wsLink } from '@mearie/react'; // or @mearie/vue, @mearie/svelte, @mearie/solid
 
 export const client = createClient({
   links: [wsLink({ url: 'wss://api.example.com/graphql' })],

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["ambient.d.ts"]
+  "include": ["env.d.ts"]
 }


### PR DESCRIPTION
## Summary

Updates documentation to reflect the new package structure:
- `mearie` is now a dev dependency (build tools and codegen)
- Framework packages include client runtime
- GraphQL operations imported from `~graphql`
- Client and links imported from framework packages

## Changes

- Install `mearie` as dev dependency (`-D` flag)
- Add `env.d.ts` setup with `import '../.mearie/graphql.d.ts'`
- Change `graphql` imports from `'mearie'` → `'~graphql'`
- Change fragment key imports from `'mearie/types'` → `'~graphql'`
- Change client/links imports from `'mearie'` → `'@mearie/{framework}'`
- Standardize framework order: React, Vue, Svelte, Solid

## Files Modified

20 documentation files across getting-started, frameworks, guides, links, and config sections.