### PR TITLE
refactor(codegen,vite): change virtual module name from $graphql to ~graphql

### DIFF
--- a/crates/native/src/codegen/generator/module_augmentation_generator.rs
+++ b/crates/native/src/codegen/generator/module_augmentation_generator.rs
@@ -74,7 +74,7 @@ impl<'a, 'b> ModuleAugmentationGenerator<'a, 'b> {
 
         let module_name = self
             .ast
-            .ts_module_declaration_name_string_literal(SPAN, "$graphql", None::<Atom>);
+            .ts_module_declaration_name_string_literal(SPAN, "~graphql", None::<Atom>);
 
         let module_decl = self.ast.ts_module_declaration(
             SPAN,
@@ -424,7 +424,7 @@ mod tests {
         assert_ok!(&result);
         let code = result.unwrap();
 
-        assert_contains!(code, "declare module \"$graphql\"");
+        assert_contains!(code, "declare module \"~graphql\"");
         assert_contains!(code, "export function graphql");
         assert_contains!(code, "type GetUser");
         assert_contains!(code, "import(\"./types.d.ts\").GetUser");
@@ -476,7 +476,7 @@ mod tests {
         assert_ok!(&result);
         let code = result.unwrap();
 
-        assert_contains!(code, "declare module \"$graphql\"");
+        assert_contains!(code, "declare module \"~graphql\"");
         assert_contains!(code, "type GetUser");
         assert_contains!(code, "type GetAllUsers");
         assert_contains!(code, "import(\"./types.d.ts\").GetUser");
@@ -527,7 +527,7 @@ mod tests {
         assert_ok!(&result);
         let code = result.unwrap();
 
-        assert_contains!(code, "declare module \"$graphql\"");
+        assert_contains!(code, "declare module \"~graphql\"");
         assert_contains!(code, "type GetUser");
         assert_contains!(code, "type UserFields");
         assert_contains!(code, "import(\"./types.d.ts\").GetUser");

--- a/examples/basic/src/main.ts
+++ b/examples/basic/src/main.ts
@@ -1,5 +1,5 @@
-import { graphql } from '$graphql';
-import type { UserProfile$key } from '$graphql';
+import { graphql } from '~graphql';
+import type { UserProfile$key } from '~graphql';
 import { useFragment, useMutation, useQuery } from '@mearie/react';
 
 const getUserQuery = useQuery(

--- a/packages/vite/src/plugin.ts
+++ b/packages/vite/src/plugin.ts
@@ -5,7 +5,7 @@ import { loadConfig, mergeConfig, type ResolvedMearieConfig } from '@mearie/conf
 import { CodegenContext, createMatcher, findFiles, logger, report } from '@mearie/codegen';
 import type { MearieOptions } from './types.ts';
 
-const VIRTUAL_MODULE_ID = '$graphql';
+const VIRTUAL_MODULE_ID = '~graphql';
 const RESOLVED_VIRTUAL_MODULE_ID = '\0' + VIRTUAL_MODULE_ID;
 
 /**


### PR DESCRIPTION
## Summary
Changes the virtual module identifier from `$graphql` to `~graphql`.

## Changes
- Updated module declaration in codegen generator
- Updated virtual module ID in Vite plugin
- Updated imports in basic example