### PR TITLE
fix(docs): improve type declaration handling in VitePress config

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
             jsx: 5,
             jsxImportSource: 'react',
             moduleResolution: ModuleResolutionKind.Bundler,
+            types: ['../.mearie/graphql.d.ts'],
           },
         },
       }),

--- a/docs/env.d.ts
+++ b/docs/env.d.ts
@@ -1,1 +1,0 @@
-import './.mearie/graphql.d.ts';

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["env.d.ts"]
+  "include": [".vitepress/**/*"]
 }


### PR DESCRIPTION
## Summary

- Removed redundant `env.d.ts` file from docs directory
- Added GraphQL type declarations directly to VitePress config's `compilerOptions.types`
- Updated `tsconfig.json` to properly include VitePress configuration files

This change improves type declaration handling in the documentation build by consolidating type references into the VitePress configuration, eliminating the need for a separate ambient declaration file.

## Test plan

- [ ] Documentation builds successfully
- [ ] TypeScript type checking passes in docs directory
- [ ] VitePress dev server runs without errors