### PR TITLE
docs: update README files to reflect new package structure and import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@
 Mearie is a type-safe GraphQL client with zero runtime overhead. Write queries
 as template literals and get automatic type generation at build time. The
 library provides normalized caching, fragment colocation, and composable
-middleware. Works with vanilla JavaScript or any framework (React, Vue, Svelte,
-and Solid bindings included).
+middleware.
+
+Mearie consists of two parts:
+- `mearie` - Build-time codegen and tooling (dev dependency)
+- `@mearie/{framework}` - Framework-specific runtime with client and bindings (React, Vue, Svelte, Solid)
 
 Here's a quick example:
 
 ```tsx
-import { createClient, httpLink, cacheLink, graphql } from 'mearie';
-import { ClientProvider, useQuery } from '@mearie/react';
+import { graphql } from '~graphql';
+import { createClient, httpLink, cacheLink, ClientProvider, useQuery } from '@mearie/react';
 
 const client = createClient({
   links: [cacheLink(), httpLink({ url: 'https://api.example.com/graphql' })],

--- a/packages/mearie/README.md
+++ b/packages/mearie/README.md
@@ -1,39 +1,49 @@
 # mearie
 
-Core GraphQL client package for Mearie.
+Build-time codegen and tooling package for Mearie.
 
-This package provides the GraphQL client runtime with support for queries,
-mutations, subscriptions, normalized caching, and composable middleware links.
+This package provides build plugins (Vite, Next.js) and code generation tools
+that extract GraphQL queries from your source code and generate TypeScript types
+at build time.
 
 ## Installation
 
+Install as a dev dependency:
+
 ```bash
-npm install mearie
+npm install -D mearie
 ```
+
+For runtime functionality, install a framework-specific package like
+[@mearie/react](https://www.npmjs.com/package/@mearie/react),
+[@mearie/vue](https://www.npmjs.com/package/@mearie/vue),
+[@mearie/svelte](https://www.npmjs.com/package/@mearie/svelte), or
+[@mearie/solid](https://www.npmjs.com/package/@mearie/solid).
 
 ## Usage
 
+Add the Vite plugin to your `vite.config.ts`:
+
 ```typescript
-import { createClient, httpLink, cacheLink, graphql } from 'mearie';
+import { defineConfig } from 'vite';
+import mearie from 'mearie/vite';
 
-const client = createClient({
-  links: [cacheLink(), httpLink({ url: 'https://api.example.com/graphql' })],
+export default defineConfig({
+  plugins: [mearie()],
 });
-
-const result = await client.query(
-  graphql(`
-    query GetUser($id: ID!) {
-      user(id: $id) {
-        id
-        name
-      }
-    }
-  `),
-  { id: '1' },
-);
 ```
 
-For framework-specific usage, see [@mearie/react](https://www.npmjs.com/package/@mearie/react),
+Or for Next.js, add to your `next.config.js`:
+
+```javascript
+import withMearie from 'mearie/next';
+
+export default withMearie({
+  // Your Next.js config
+});
+```
+
+For framework-specific runtime usage, see [@mearie/react](https://www.npmjs.com/package/@mearie/react),
 [@mearie/vue](https://www.npmjs.com/package/@mearie/vue),
 [@mearie/svelte](https://www.npmjs.com/package/@mearie/svelte), or
 [@mearie/solid](https://www.npmjs.com/package/@mearie/solid).

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -2,20 +2,26 @@
 
 React bindings for Mearie GraphQL client.
 
-This package provides React hooks and components for using Mearie in React
-applications.
+This package provides React hooks, components, and the GraphQL client runtime
+for using Mearie in React applications.
 
 ## Installation
 
 ```bash
-npm install mearie @mearie/react
+npm install -D mearie
+npm install @mearie/react
 ```
+
+The `mearie` package provides build-time code generation, while `@mearie/react`
+includes the runtime client and React-specific hooks.
 
 ## Usage
 
+First, create a client and wrap your app with the provider:
+
 ```tsx
-import { createClient, httpLink, cacheLink, graphql } from 'mearie';
-import { ClientProvider, useQuery } from '@mearie/react';
+// src/App.tsx
+import { createClient, httpLink, cacheLink, ClientProvider } from '@mearie/react';
 
 const client = createClient({
   links: [cacheLink(), httpLink({ url: 'https://api.example.com/graphql' })],
@@ -24,12 +30,24 @@ const client = createClient({
 function App() {
   return (
     <ClientProvider client={client}>
-      <UserProfile userId="1" />
+      {/* Your app components */}
     </ClientProvider>
   );
 }
+```
 
-function UserProfile({ userId }: { userId: string }) {
+Then use it in your components:
+
+```tsx
+// src/components/UserProfile.tsx
+import { graphql } from '~graphql';
+import { useQuery } from '@mearie/react';
+
+interface UserProfileProps {
+  userId: string;
+}
+
+function UserProfile({ userId }: UserProfileProps) {
   const { data, loading } = useQuery(
     graphql(`
       query GetUser($id: ID!) {

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -2,21 +2,27 @@
 
 Solid bindings for Mearie GraphQL client.
 
-This package provides Solid primitives and components for using Mearie in Solid
-applications.
+This package provides Solid primitives, components, and the GraphQL client
+runtime for using Mearie in Solid applications.
 
 ## Installation
 
 ```bash
-npm install mearie @mearie/solid
+npm install -D mearie
+npm install @mearie/solid
 ```
+
+The `mearie` package provides build-time code generation, while `@mearie/solid`
+includes the runtime client and Solid-specific primitives.
 
 ## Usage
 
+First, create a client and wrap your app with the provider:
+
 ```tsx
+// src/App.tsx
 import { type Component } from 'solid-js';
-import { createClient, httpLink, cacheLink, graphql } from 'mearie';
-import { ClientProvider, createQuery } from '@mearie/solid';
+import { createClient, httpLink, cacheLink, ClientProvider } from '@mearie/solid';
 
 const client = createClient({
   links: [cacheLink(), httpLink({ url: 'https://api.example.com/graphql' })],
@@ -25,10 +31,19 @@ const client = createClient({
 const App: Component = () => {
   return (
     <ClientProvider client={client}>
-      <UserProfile userId="1" />
+      {/* Your app components */}
     </ClientProvider>
   );
 };
+```
+
+Then use it in your components:
+
+```tsx
+// src/components/UserProfile.tsx
+import { type Component } from 'solid-js';
+import { graphql } from '~graphql';
+import { createQuery } from '@mearie/solid';
 
 interface UserProfileProps {
   userId: string;

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -2,20 +2,42 @@
 
 Svelte bindings for Mearie GraphQL client.
 
-This package provides Svelte stores and utilities for using Mearie in Svelte
-applications.
+This package provides Svelte stores, utilities, and the GraphQL client runtime
+for using Mearie in Svelte applications.
 
 ## Installation
 
 ```bash
-npm install mearie @mearie/svelte
+npm install -D mearie
+npm install @mearie/svelte
 ```
+
+The `mearie` package provides build-time code generation, while `@mearie/svelte`
+includes the runtime client and Svelte-specific stores.
 
 ## Usage
 
+First, create a client and set it up in your app:
+
 ```svelte
+<!-- src/App.svelte -->
 <script lang="ts">
-import { createClient, httpLink, cacheLink, graphql } from 'mearie';
+import { createClient, httpLink, cacheLink, setClient } from '@mearie/svelte';
+
+const client = createClient({
+  links: [cacheLink(), httpLink({ url: 'https://api.example.com/graphql' })],
+});
+
+setClient(client);
+</script>
+```
+
+Then use it in your components:
+
+```svelte
+<!-- src/components/UserProfile.svelte -->
+<script lang="ts">
+import { graphql } from '~graphql';
 import { createQuery } from '@mearie/svelte';
 
 interface Props {

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -2,20 +2,44 @@
 
 Vue bindings for Mearie GraphQL client.
 
-This package provides Vue composables and plugins for using Mearie in Vue
-applications.
+This package provides Vue composables, plugins, and the GraphQL client runtime
+for using Mearie in Vue applications.
 
 ## Installation
 
 ```bash
-npm install mearie @mearie/vue
+npm install -D mearie
+npm install @mearie/vue
 ```
+
+The `mearie` package provides build-time code generation, while `@mearie/vue`
+includes the runtime client and Vue-specific composables.
 
 ## Usage
 
+First, create a client and set up the plugin in your app:
+
+```typescript
+// src/main.ts
+import { createApp } from 'vue';
+import { createClient, httpLink, cacheLink, ClientPlugin } from '@mearie/vue';
+import App from './App.vue';
+
+const client = createClient({
+  links: [cacheLink(), httpLink({ url: 'https://api.example.com/graphql' })],
+});
+
+const app = createApp(App);
+app.use(ClientPlugin, { client });
+app.mount('#app');
+```
+
+Then use it in your components:
+
 ```vue
+<!-- src/components/UserProfile.vue -->
 <script setup lang="ts">
-import { createClient, httpLink, cacheLink, graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/vue';
 
 const props = defineProps<{ userId: string }>();


### PR DESCRIPTION
## Overview
Updates all README files to reflect the new package structure and import paths

## Changes
- Updated import paths: `graphql` is now imported from `~graphql` instead of `mearie`
- Clarified that `mearie` is a build-time codegen package (dev dependency)
- Framework packages (`@mearie/react`, `@mearie/vue`, etc.) now include both runtime client and framework bindings
- Updated installation guides to show `mearie` as dev dependency and framework packages as regular dependencies
- Reorganized usage examples into client setup and component usage sections for consistency

## Impact
Documentation now accurately reflects the package architecture after recent restructuring