### PR TITLE
chore(typescript): standardize TypeScript configuration across packages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitepress';
 import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons';
 import { transformerTwoslash } from '@shikijs/vitepress-twoslash';
 import { createFileSystemTypesCache } from '@shikijs/vitepress-twoslash/cache-fs';
-import { mearie } from '@mearie/vite';
+import mearie from 'mearie/vite';
 import { ModuleResolutionKind } from 'typescript';
 
 export default defineConfig({

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,15 +5,16 @@
   "type": "module",
   "scripts": {
     "build": "vitepress build",
-    "dev": "vitepress dev"
+    "dev": "vitepress dev",
+    "typecheck": "tsc"
   },
   "devDependencies": {
     "@mearie/react": "workspace:*",
-    "@mearie/vite": "workspace:*",
     "@shikijs/vitepress-twoslash": "^3.13.0",
     "@types/react": "^19.2.2",
     "mearie": "workspace:*",
     "react": "^19.2.0",
+    "typescript": "catalog:",
     "vitepress": "2.0.0-alpha.12",
     "vitepress-plugin-group-icons": "^1.6.4"
   }

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc"
   },
   "devDependencies": {
     "@mearie/react": "workspace:*",
     "mearie": "workspace:*",
+    "typescript": "catalog:",
     "vite": "^7.1.10"
   }
 }

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "publish:prepare": "node scripts/prepare-publish.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "turbo typecheck"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
@@ -56,9 +56,9 @@
     "prettier-plugin-packagejson": "^2.5.19",
     "tinyglobby": "^0.2.15",
     "turbo": "^2.5.8",
-    "typescript": "^5.9.3",
+    "typescript": "catalog:",
     "typescript-eslint": "^8.46.1",
-    "vitest": "catalog:",
+    "vitest": "^3.2.4",
     "wrangler": "^4.43.0"
   },
   "packageManager": "pnpm@10.18.3+sha512.bbd16e6d7286fd7e01f6b3c0b3c932cda2965c06a908328f74663f10a9aea51f1129eea615134bf992831b009eabe167ecb7008b597f40ff9bc75946aadfb08d",

--- a/packages/codegen/package.json
+++ b/packages/codegen/package.json
@@ -13,8 +13,7 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@logtape/logtape": "^1.1.1",
@@ -31,8 +30,7 @@
     "@vue/compiler-sfc": "^3.5.22",
     "svelte": "^5.41.0",
     "tsdown": "catalog:",
-    "typescript": "^5.9.3",
-    "vitest": "catalog:"
+    "typescript": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/codegen/tsconfig.json
+++ b/packages/codegen/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/codegen/tsdown.config.ts
+++ b/packages/codegen/tsdown.config.ts
@@ -3,4 +3,5 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
   format: ['esm', 'cjs'],
   dts: true,
+  external: ['@vue/compiler-sfc', 'svelte'],
 });

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -13,8 +13,7 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "typecheck": "tsc"
   },
   "dependencies": {
     "c12": "^3.3.1",
@@ -22,7 +21,7 @@
   },
   "devDependencies": {
     "tsdown": "catalog:",
-    "vitest": "catalog:"
+    "typescript": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,15 +13,14 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@mearie/shared": "workspace:*"
   },
   "devDependencies": {
     "tsdown": "catalog:",
-    "vitest": "catalog:"
+    "typescript": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/mearie/package.json
+++ b/packages/mearie/package.json
@@ -15,17 +15,16 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@mearie/config": "workspace:*",
-    "@mearie/core": "workspace:*",
+    "@mearie/shared": "workspace:*",
     "@mearie/vite": "workspace:*"
   },
   "devDependencies": {
     "tsdown": "catalog:",
-    "vitest": "catalog:"
+    "typescript": "catalog:"
   },
   "publishConfig": {
     "access": "public",
@@ -34,6 +33,11 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js",
         "require": "./dist/index.cjs"
+      },
+      "./types": {
+        "types": "./dist/types.d.ts",
+        "import": "./dist/types.js",
+        "require": "./dist/types.cjs"
       },
       "./vite": {
         "types": "./dist/vite.d.ts",

--- a/packages/mearie/src/types.ts
+++ b/packages/mearie/src/types.ts
@@ -1,1 +1,1 @@
-export type { Artifact, Nullable, List, FragmentRefs } from '@mearie/core';
+export type { Artifact, Nullable, List, FragmentRefs } from '@mearie/shared';

--- a/packages/mearie/tsconfig.json
+++ b/packages/mearie/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,7 +12,8 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@mearie/core": "workspace:*"
@@ -20,7 +21,8 @@
   "devDependencies": {
     "@types/react": "^19.2.2",
     "react": "^19.2.0",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,12 +13,11 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "typecheck": "tsc"
   },
   "devDependencies": {
     "tsdown": "catalog:",
-    "vitest": "catalog:"
+    "typescript": "catalog:"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -12,14 +12,16 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@mearie/core": "workspace:*"
   },
   "devDependencies": {
     "solid-js": "^1.9.9",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "solid-js": "^1.8.0"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -12,14 +12,16 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@mearie/core": "workspace:*"
   },
   "devDependencies": {
     "svelte": "^5.41.0",
-    "tsdown": "catalog:"
+    "tsdown": "catalog:",
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "svelte": "^5.0.0"

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -13,10 +13,7 @@
   ],
   "scripts": {
     "build": "tsdown",
-    "test": "vitest run",
-    "test:all": "pnpm test && pnpm test:examples",
-    "test:examples": "tsx scripts/test-examples.ts",
-    "test:watch": "vitest"
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@mearie/codegen": "workspace:*",
@@ -25,8 +22,8 @@
   "devDependencies": {
     "tsdown": "catalog:",
     "tsx": "^4.20.6",
-    "vite": "^7.1.10",
-    "vitest": "catalog:"
+    "typescript": "catalog:",
+    "vite": "^7.1.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/vite/tsconfig.json
+++ b/packages/vite/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -12,13 +12,15 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsdown"
+    "build": "tsdown",
+    "typecheck": "tsc"
   },
   "dependencies": {
     "@mearie/core": "workspace:*"
   },
   "devDependencies": {
     "tsdown": "catalog:",
+    "typescript": "catalog:",
     "vue": "^3.5.22"
   },
   "peerDependencies": {

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,9 @@ catalogs:
     tsdown:
       specifier: ^0.15.8
       version: 0.15.8
-    vitest:
-      specifier: ^3.2.4
-      version: 3.2.4
+    typescript:
+      specifier: ^5.9.3
+      version: 5.9.3
 
 importers:
 
@@ -60,13 +60,13 @@ importers:
         specifier: ^2.5.8
         version: 2.5.8
       typescript:
-        specifier: ^5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.46.1
         version: 8.46.1(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       vitest:
-        specifier: 'catalog:'
+        specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.8.1)(jiti@2.6.1)(tsx@4.20.6)
       wrangler:
         specifier: ^4.43.0
@@ -83,9 +83,6 @@ importers:
       '@mearie/react':
         specifier: workspace:*
         version: link:../packages/react
-      '@mearie/vite':
-        specifier: workspace:*
-        version: link:../packages/vite
       '@shikijs/vitepress-twoslash':
         specifier: ^3.13.0
         version: 3.13.0(typescript@5.9.3)
@@ -98,6 +95,9 @@ importers:
       react:
         specifier: ^19.2.0
         version: 19.2.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
       vitepress:
         specifier: 2.0.0-alpha.12
         version: 2.0.0-alpha.12(@types/node@24.8.1)(change-case@5.4.4)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.3)
@@ -113,6 +113,9 @@ importers:
       mearie:
         specifier: workspace:*
         version: link:../../packages/mearie
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
       vite:
         specifier: ^7.1.10
         version: 7.1.10(@types/node@24.8.1)(jiti@2.6.1)(tsx@4.20.6)
@@ -157,11 +160,8 @@ importers:
         specifier: 'catalog:'
         version: 0.15.8(typescript@5.9.3)
       typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
-      vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.8.1)(jiti@2.6.1)(tsx@4.20.6)
+        version: 5.9.3
 
   packages/config:
     dependencies:
@@ -175,9 +175,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.15.8(typescript@5.9.3)
-      vitest:
+      typescript:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.8.1)(jiti@2.6.1)(tsx@4.20.6)
+        version: 5.9.3
 
   packages/core:
     dependencies:
@@ -188,18 +188,18 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.15.8(typescript@5.9.3)
-      vitest:
+      typescript:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.8.1)(jiti@2.6.1)(tsx@4.20.6)
+        version: 5.9.3
 
   packages/mearie:
     dependencies:
       '@mearie/config':
         specifier: workspace:*
         version: link:../config
-      '@mearie/core':
+      '@mearie/shared':
         specifier: workspace:*
-        version: link:../core
+        version: link:../shared
       '@mearie/vite':
         specifier: workspace:*
         version: link:../vite
@@ -207,9 +207,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.15.8(typescript@5.9.3)
-      vitest:
+      typescript:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.8.1)(jiti@2.6.1)(tsx@4.20.6)
+        version: 5.9.3
 
   packages/react:
     dependencies:
@@ -226,15 +226,18 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.15.8(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   packages/shared:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
         version: 0.15.8(typescript@5.9.3)
-      vitest:
+      typescript:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.8.1)(jiti@2.6.1)(tsx@4.20.6)
+        version: 5.9.3
 
   packages/solid:
     dependencies:
@@ -248,6 +251,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.15.8(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   packages/svelte:
     dependencies:
@@ -261,6 +267,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.15.8(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
 
   packages/vite:
     dependencies:
@@ -277,12 +286,12 @@ importers:
       tsx:
         specifier: ^4.20.6
         version: 4.20.6
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
       vite:
         specifier: ^7.1.10
         version: 7.1.10(@types/node@24.8.1)(jiti@2.6.1)(tsx@4.20.6)
-      vitest:
-        specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.8.1)(jiti@2.6.1)(tsx@4.20.6)
 
   packages/vue:
     dependencies:
@@ -293,6 +302,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.15.8(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
       vue:
         specifier: ^3.5.22
         version: 3.5.22(typescript@5.9.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,5 +7,5 @@ packages:
 
 catalog:
   tsdown: ^0.15.8
-  vitest: ^3.2.4
+  typescript: ^5.9.3
   '@types/node': '^24.8.1'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
     "erasableSyntaxOnly": true,
     "verbatimModuleSyntax": true
   },
-  "exclude": ["**/dist", "**/node_modules", "packages/react", "packages/solid"]
+  "exclude": ["**/dist", "**/node_modules"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,7 @@
     "dev": {
       "persistent": true,
       "cache": false
-    }
+    },
+    "typecheck": {}
   }
 }


### PR DESCRIPTION
## Summary

- Add `tsconfig.json` to all packages for consistent type checking
- Add `typecheck` script to all package.json files
- Update pnpm workspace catalog from `vitest` to `typescript`
- Add `typecheck` task to turbo.json
- Clean up package dependencies (remove vitest, use typescript catalog)
- Update `mearie` package dependency from `@mearie/core` to `@mearie/shared`
- Update import path in VitePress config

## Test plan

- [ ] Run `pnpm typecheck` to verify no type errors across all packages
- [ ] Run `pnpm build` to ensure builds complete successfully
- [ ] Run `pnpm test` to verify tests pass