### PR TITLE
fix(changeset): correct mearie package bump level from major to minor

### DIFF
--- a/.changeset/proud-lions-dance.md
+++ b/.changeset/proud-lions-dance.md
@@ -1,5 +1,5 @@
 ---
-'mearie': major
+'mearie': minor
 ---
 
 Remove `mearie/config` export path in favor of importing `defineConfig` directly from `mearie`


### PR DESCRIPTION
## Overview
Corrected the version bump level for the mearie package changeset from major to minor.

## Changes
- Modified `.changeset/proud-lions-dance.md` to change version bump from `major` to `minor`
- This reflects that the removal of `mearie/config` export path should be a minor change rather than major

## Impact
This ensures the correct semantic version will be applied when the changeset is consumed during the release process.