### PR TITLE
docs: update import paths in guides to reflect new package structure

### DIFF
--- a/docs/guides/scalars.md
+++ b/docs/guides/scalars.md
@@ -22,7 +22,7 @@ Working with custom scalars requires two configurations:
 Configure type mappings in `mearie.config.ts`:
 
 ```typescript
-import { defineConfig } from 'mearie/config';
+import { defineConfig } from 'mearie';
 
 export default defineConfig({
   // ...
@@ -39,7 +39,7 @@ export default defineConfig({
 Configure runtime transformations when creating your client:
 
 ```typescript
-import { createClient, httpLink, cacheLink } from 'mearie';
+import { createClient, httpLink, cacheLink } from '@mearie/react';
 
 export const client = createClient({
   scalars: {

--- a/docs/why-mearie.md
+++ b/docs/why-mearie.md
@@ -20,7 +20,7 @@ Mearie (메아리, meaning "echo" in Korean) is a zero-config GraphQL client for
 ::: code-group
 
 ```tsx [React]
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/react';
 
 export const UserProfile = ({ userId }: { userId: string }) => {
@@ -44,7 +44,7 @@ export const UserProfile = ({ userId }: { userId: string }) => {
 
 ```vue [Vue]
 <script setup lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { useQuery } from '@mearie/vue';
 
 const props = defineProps<{ userId: string }>();
@@ -71,7 +71,7 @@ const { data, loading } = useQuery(
 
 ```svelte [Svelte]
 <script lang="ts">
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createQuery } from '@mearie/svelte';
 
 interface Props {
@@ -103,7 +103,7 @@ const query = createQuery(
 
 ```tsx [Solid]
 import { type Component } from 'solid-js';
-import { graphql } from 'mearie';
+import { graphql } from '~graphql';
 import { createQuery } from '@mearie/solid';
 
 interface UserProfileProps {


### PR DESCRIPTION
## Summary
Update import paths in documentation to align with the new package structure.

## Changes
- Update `mearie/config` imports to `mearie` in scalars guide
- Update `mearie` imports to `~graphql` in framework examples
- Update client imports to `@mearie/react` in scalars guide

## Related
Follows up on #34 which updated README files for the new package structure.