### PR TITLE
refactor(core): remove error handling from stream system

### DIFF
--- a/.changeset/silent-lions-rest.md
+++ b/.changeset/silent-lions-rest.md
@@ -1,0 +1,5 @@
+---
+'@mearie/core': minor
+---
+
+Remove error handling from stream system to simplify implementation

--- a/packages/core/src/stream/operators/filter.test.ts
+++ b/packages/core/src/stream/operators/filter.test.ts
@@ -5,7 +5,7 @@ import { fromValue } from '../sources/from-value.ts';
 import { collectAll } from '../sinks/collect-all.ts';
 import { pipe } from '../pipe.ts';
 import { map } from './map.ts';
-import type { Sink, Talkback } from '../types.ts';
+import type { Talkback } from '../types.ts';
 
 describe('filter', () => {
   describe('basic filtering', () => {
@@ -329,47 +329,6 @@ describe('filter', () => {
     });
   });
 
-  describe('error handling', () => {
-    it('should propagate errors from source', async () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.error(new Error('Source error'));
-      };
-
-      await expect(
-        pipe(
-          source,
-          filter((x) => x > 0),
-          collectAll,
-        ),
-      ).rejects.toThrow('Source error');
-    });
-
-    it('should propagate errors after filtering some values', async () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.next(2);
-        sink.error(new Error('Error after values'));
-      };
-
-      await expect(
-        pipe(
-          source,
-          filter((x) => x % 2 === 0),
-          collectAll,
-        ),
-      ).rejects.toThrow('Error after values');
-    });
-  });
-
   describe('completion', () => {
     it('should complete when source completes', async () => {
       const source = fromArray([1, 2, 3, 4, 5]);
@@ -421,7 +380,6 @@ describe('filter', () => {
           receivedTalkback = tb;
         },
         next: () => {},
-        error: () => {},
         complete: () => {},
       });
 
@@ -448,7 +406,6 @@ describe('filter', () => {
             talkback.cancel();
           }
         },
-        error: () => {},
         complete: () => {},
       });
 
@@ -505,12 +462,7 @@ describe('filter', () => {
     });
 
     it('should filter arrays by length', async () => {
-      const source = fromArray([
-        [1, 2],
-        [1, 2, 3],
-        [1],
-        [1, 2, 3, 4],
-      ]);
+      const source = fromArray([[1, 2], [1, 2, 3], [1], [1, 2, 3, 4]]);
 
       const result = await pipe(
         source,

--- a/packages/core/src/stream/operators/filter.ts
+++ b/packages/core/src/stream/operators/filter.ts
@@ -17,9 +17,6 @@ export const filter = <T>(predicate: (value: T) => boolean): Operator<T> => {
             sink.next(value);
           }
         },
-        error(err) {
-          sink.error(err);
-        },
         complete() {
           sink.complete();
         },

--- a/packages/core/src/stream/operators/map.test.ts
+++ b/packages/core/src/stream/operators/map.test.ts
@@ -4,7 +4,7 @@ import { fromArray } from '../sources/from-array.ts';
 import { fromValue } from '../sources/from-value.ts';
 import { collectAll } from '../sinks/collect-all.ts';
 import { pipe } from '../pipe.ts';
-import type { Sink, Talkback } from '../types.ts';
+import type { Talkback } from '../types.ts';
 
 describe('map', () => {
   describe('basic transformation', () => {
@@ -241,47 +241,6 @@ describe('map', () => {
     });
   });
 
-  describe('error handling', () => {
-    it('should propagate errors from source', async () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.error(new Error('Source error'));
-      };
-
-      await expect(
-        pipe(
-          source,
-          map((x) => x * 2),
-          collectAll,
-        ),
-      ).rejects.toThrow('Source error');
-    });
-
-    it('should propagate errors even after mapping some values', async () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.next(2);
-        sink.error(new Error('Error after values'));
-      };
-
-      await expect(
-        pipe(
-          source,
-          map((x) => x * 2),
-          collectAll,
-        ),
-      ).rejects.toThrow('Error after values');
-    });
-  });
-
   describe('completion', () => {
     it('should complete when source completes', async () => {
       const source = fromArray([1, 2, 3]);
@@ -321,7 +280,6 @@ describe('map', () => {
           receivedTalkback = tb;
         },
         next: () => {},
-        error: () => {},
         complete: () => {},
       });
 
@@ -348,7 +306,6 @@ describe('map', () => {
             talkback.cancel();
           }
         },
-        error: () => {},
         complete: () => {},
       });
 

--- a/packages/core/src/stream/operators/map.ts
+++ b/packages/core/src/stream/operators/map.ts
@@ -15,9 +15,6 @@ export const map = <A, B>(fn: (value: A) => B): Operator<A, B> => {
         next(value) {
           sink.next(fn(value));
         },
-        error(err) {
-          sink.error(err);
-        },
         complete() {
           sink.complete();
         },

--- a/packages/core/src/stream/operators/merge-map.ts
+++ b/packages/core/src/stream/operators/merge-map.ts
@@ -39,23 +39,11 @@ export const mergeMap = <A, B>(fn: (value: A) => Source<B>): Operator<A, B> => {
                 sink.next(innerValue);
               }
             },
-            error(err) {
-              if (!ended) {
-                ended = true;
-                sink.error(err);
-              }
-            },
             complete() {
               activeInner--;
               checkComplete();
             },
           });
-        },
-        error(err) {
-          if (!ended) {
-            ended = true;
-            sink.error(err);
-          }
         },
         complete() {
           outerCompleted = true;

--- a/packages/core/src/stream/operators/merge.test.ts
+++ b/packages/core/src/stream/operators/merge.test.ts
@@ -5,7 +5,6 @@ import { fromValue } from '../sources/from-value.ts';
 import { collectAll } from '../sinks/collect-all.ts';
 import { pipe } from '../pipe.ts';
 import { map } from './map.ts';
-import type { Sink } from '../types.ts';
 
 describe('merge', () => {
   describe('basic merging', () => {
@@ -124,7 +123,6 @@ describe('merge', () => {
           tb.pull();
         },
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -139,85 +137,12 @@ describe('merge', () => {
       merge()({
         start: () => {},
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
       });
 
       expect(completed).toBe(true);
-    });
-  });
-
-  describe('error handling', () => {
-    it('should propagate errors from any source', async () => {
-      const source1 = fromArray([1, 2]);
-      const source2 = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(3);
-        sink.error(new Error('Source 2 error'));
-      };
-
-      await expect(pipe(merge(source1, source2), collectAll)).rejects.toThrow('Source 2 error');
-    });
-
-    it('should cancel other sources when one errors', async () => {
-      let source1Cancelled = false;
-      const source1 = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {
-            source1Cancelled = true;
-          },
-        });
-        sink.next(1);
-        sink.next(2);
-      };
-
-      const source2 = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.error(new Error('Source 2 error'));
-      };
-
-      await expect(pipe(merge(source1, source2), collectAll)).rejects.toThrow('Source 2 error');
-
-      expect(source1Cancelled).toBe(true);
-    });
-
-    it('should not emit values after error', () => {
-      const emitted: number[] = [];
-
-      const source1 = fromArray([1, 2, 3]);
-      const source2 = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.error(new Error('Early error'));
-      };
-
-      try {
-        pipe(merge(source1, source2))({
-          start: (tb) => {
-            tb.pull();
-          },
-          next: (value) => {
-            emitted.push(value);
-          },
-          error: () => {},
-          complete: () => {},
-        });
-      } catch {
-        // Ignore error
-      }
-
-      expect(emitted.length).toBeLessThanOrEqual(3);
     });
   });
 
@@ -237,7 +162,6 @@ describe('merge', () => {
           pullCalled = true;
         },
         next: () => {},
-        error: () => {},
         complete: () => {},
       });
 
@@ -259,7 +183,6 @@ describe('merge', () => {
           cancelCalled = true;
         },
         next: () => {},
-        error: () => {},
         complete: () => {},
       });
 

--- a/packages/core/src/stream/operators/merge.ts
+++ b/packages/core/src/stream/operators/merge.ts
@@ -50,15 +50,6 @@ export const merge = <T>(...sources: Source<T>[]): Source<T> => {
             sink.next(value);
           }
         },
-        error(err) {
-          if (!ended) {
-            ended = true;
-            for (const tb of talkbacks) {
-              tb.cancel();
-            }
-            sink.error(err);
-          }
-        },
         complete() {
           activeCount--;
           checkComplete();

--- a/packages/core/src/stream/operators/share.test.ts
+++ b/packages/core/src/stream/operators/share.test.ts
@@ -33,7 +33,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values1.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -41,7 +40,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values2.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -63,7 +61,6 @@ describe('share', () => {
             sink.start(tb);
           },
           next: (value) => sink.next(value),
-          error: (error) => sink.error(error),
           complete: () => sink.complete(),
         });
       };
@@ -75,7 +72,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -83,7 +79,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -91,7 +86,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -119,7 +113,6 @@ describe('share', () => {
       shared({
         start: () => {},
         next: () => {},
-        error: () => {},
         complete: () => {},
       });
 
@@ -144,7 +137,6 @@ describe('share', () => {
         shared({
           start: () => {},
           next: () => {},
-          error: () => {},
           complete: () => resolve(),
         });
       });
@@ -169,7 +161,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values1.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -177,7 +168,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values2.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -185,7 +175,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values3.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -208,7 +197,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values1.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -216,7 +204,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values2.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -241,7 +228,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => {
               completed1 = true;
               resolve();
@@ -252,7 +238,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => {
               completed2 = true;
               resolve();
@@ -263,7 +248,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => {
               completed3 = true;
               resolve();
@@ -285,75 +269,7 @@ describe('share', () => {
         shared({
           start: () => {},
           next: () => {},
-          error: () => {},
           complete: () => resolve(),
-        });
-      });
-    });
-  });
-
-  describe('error handling', () => {
-    it('should notify all subscribers of errors', async () => {
-      const source: Source<number> = (sink) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.error(new Error('Test error'));
-      };
-
-      const shared = pipe(source, share());
-
-      const errors: Error[] = [];
-
-      await Promise.all([
-        new Promise<void>((resolve) => {
-          shared({
-            start: () => {},
-            next: () => {},
-            error: (err) => {
-              errors.push(err as Error);
-              resolve();
-            },
-            complete: () => {},
-          });
-        }),
-        new Promise<void>((resolve) => {
-          shared({
-            start: () => {},
-            next: () => {},
-            error: (err) => {
-              errors.push(err as Error);
-              resolve();
-            },
-            complete: () => {},
-          });
-        }),
-      ]);
-
-      expect(errors.length).toBe(2);
-      expect(errors[0]!.message).toBe('Test error');
-      expect(errors[1]!.message).toBe('Test error');
-    });
-
-    it('should clear subscribers after error', async () => {
-      const source: Source<number> = (sink) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.error(new Error('Test error'));
-      };
-
-      const shared = pipe(source, share());
-
-      await new Promise<void>((resolve) => {
-        shared({
-          start: () => {},
-          next: () => {},
-          error: () => resolve(),
-          complete: () => {},
         });
       });
     });
@@ -376,7 +292,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values1.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -384,7 +299,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values2.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -410,7 +324,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values1.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -418,7 +331,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values2.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -444,7 +356,6 @@ describe('share', () => {
               talkback1Received = !!tb;
             },
             next: () => {},
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -454,7 +365,6 @@ describe('share', () => {
               talkback2Received = !!tb;
             },
             next: () => {},
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -486,7 +396,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -494,7 +403,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -502,7 +410,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -525,7 +432,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values1.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -533,7 +439,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values2.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -558,7 +463,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values1.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -566,7 +470,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => values2.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -606,7 +509,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -614,7 +516,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -622,7 +523,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: () => {},
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -654,7 +554,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => results.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),
@@ -662,7 +561,6 @@ describe('share', () => {
           shared({
             start: () => {},
             next: (v) => results.push(v),
-            error: () => {},
             complete: () => resolve(),
           });
         }),

--- a/packages/core/src/stream/operators/share.ts
+++ b/packages/core/src/stream/operators/share.ts
@@ -31,17 +31,10 @@ export const share = <T>(): Operator<T> => {
                 s.next(value);
               }
             },
-            error(err) {
-              const sinksToNotify = [...sinks];
-              sinks.length = 0;
-              for (const s of sinksToNotify) {
-                s.error(err);
-              }
-            },
             complete() {
-              const sinksToNotify = [...sinks];
+              const ss = [...sinks];
               sinks.length = 0;
-              for (const s of sinksToNotify) {
+              for (const s of ss) {
                 s.complete();
               }
             },

--- a/packages/core/src/stream/operators/take-until.test.ts
+++ b/packages/core/src/stream/operators/take-until.test.ts
@@ -70,7 +70,6 @@ describe('takeUntil', () => {
             next();
           }
         },
-        error: () => {},
         complete: () => {},
       });
 
@@ -94,7 +93,6 @@ describe('takeUntil', () => {
         next: (value) => {
           emitted.push(value);
         },
-        error: () => {},
         complete: () => {},
       });
 
@@ -122,7 +120,6 @@ describe('takeUntil', () => {
       )({
         start: () => {},
         next: () => {},
-        error: () => {},
         complete: () => {},
       });
 
@@ -149,32 +146,6 @@ describe('takeUntil', () => {
 
       expect(notifierCancelled).toBe(true);
     });
-
-    it('should cancel notifier when source errors', async () => {
-      let notifierCancelled = false;
-
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.error(new Error('Source error'));
-      };
-
-      const notifier = (sink: Sink<void>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {
-            notifierCancelled = true;
-          },
-        });
-      };
-
-      await expect(pipe(source, takeUntil(notifier), collectAll)).rejects.toThrow('Source error');
-
-      expect(notifierCancelled).toBe(true);
-    });
   });
 
   describe('completion', () => {
@@ -193,7 +164,6 @@ describe('takeUntil', () => {
           tb.pull();
         },
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -216,55 +186,12 @@ describe('takeUntil', () => {
           tb.pull();
         },
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
       });
 
       expect(completed).toBe(true);
-    });
-  });
-
-  describe('error handling', () => {
-    it('should propagate errors from source', async () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.error(new Error('Source error'));
-      };
-
-      const { source: notifier } = makeSubject<void>();
-
-      await expect(pipe(source, takeUntil(notifier), collectAll)).rejects.toThrow('Source error');
-    });
-
-    it('should not propagate errors from notifier', async () => {
-      const source = fromArray([1, 2, 3]);
-
-      const notifier = (sink: Sink<void>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.error(new Error('Notifier error'));
-      };
-
-      const result = await pipe(source, takeUntil(notifier), collectAll);
-
-      expect(result).toEqual([1, 2, 3]);
-    });
-
-    it('should not propagate completion from notifier', async () => {
-      const source = fromArray([1, 2, 3]);
-      const notifier = fromArray<void>([]);
-
-      const result = await pipe(source, takeUntil(notifier), collectAll);
-
-      expect(result).toEqual([1, 2, 3]);
     });
   });
 

--- a/packages/core/src/stream/operators/take-until.ts
+++ b/packages/core/src/stream/operators/take-until.ts
@@ -35,9 +35,6 @@ export const takeUntil = <T>(notifier: Source<unknown>): Operator<T> => {
         next() {
           complete();
         },
-        error() {
-          // do nothing
-        },
         complete() {
           // do nothing
         },
@@ -51,15 +48,6 @@ export const takeUntil = <T>(notifier: Source<unknown>): Operator<T> => {
         next(value) {
           if (!completed) {
             sink.next(value);
-          }
-        },
-        error(err) {
-          if (!completed) {
-            completed = true;
-            if (notifierTalkback) {
-              notifierTalkback.cancel();
-            }
-            sink.error(err);
           }
         },
         complete() {

--- a/packages/core/src/stream/operators/take.test.ts
+++ b/packages/core/src/stream/operators/take.test.ts
@@ -121,7 +121,6 @@ describe('take', () => {
             });
           },
           next: (value) => sink.next(value),
-          error: (error) => sink.error(error),
           complete: () => sink.complete(),
         });
       };
@@ -206,7 +205,6 @@ describe('take', () => {
           tb.pull();
         },
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -227,7 +225,6 @@ describe('take', () => {
           tb.pull();
         },
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -249,7 +246,6 @@ describe('take', () => {
           startCalled = true;
         },
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -257,37 +253,6 @@ describe('take', () => {
 
       expect(startCalled).toBe(true);
       expect(completed).toBe(true);
-    });
-  });
-
-  describe('error handling', () => {
-    it('should propagate errors from source', async () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.error(new Error('Source error'));
-      };
-
-      await expect(pipe(source, take(5), collectAll)).rejects.toThrow('Source error');
-    });
-
-    it('should not propagate errors after taking all values', async () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.next(2);
-        sink.error(new Error('Should not propagate'));
-      };
-
-      const result = await pipe(source, take(2), collectAll);
-
-      expect(result).toEqual([1, 2]);
     });
   });
 
@@ -304,7 +269,6 @@ describe('take', () => {
           receivedTalkback = tb;
         },
         next: () => {},
-        error: () => {},
         complete: () => {},
       });
 
@@ -420,7 +384,6 @@ describe('take', () => {
         next: (value) => {
           nextCalls.push(value);
         },
-        error: () => {},
         complete: () => {},
       });
 

--- a/packages/core/src/stream/operators/take.ts
+++ b/packages/core/src/stream/operators/take.ts
@@ -33,9 +33,6 @@ export const take = <T>(count: number): Operator<T> => {
             }
           }
         },
-        error(err) {
-          sink.error(err);
-        },
         complete() {
           sink.complete();
         },

--- a/packages/core/src/stream/operators/tap.test.ts
+++ b/packages/core/src/stream/operators/tap.test.ts
@@ -6,7 +6,6 @@ import { collectAll } from '../sinks/collect-all.ts';
 import { pipe } from '../pipe.ts';
 import { map } from './map.ts';
 import { filter } from './filter.ts';
-import type { Sink } from '../types.ts';
 
 describe('tap', () => {
   describe('basic behavior', () => {
@@ -330,59 +329,6 @@ describe('tap', () => {
       );
 
       expect(tapped).toEqual(['a', '', 'c']);
-    });
-  });
-
-  describe('error handling', () => {
-    it('should propagate errors from source', async () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.error(new Error('Source error'));
-      };
-
-      const tapped: number[] = [];
-
-      await expect(
-        pipe(
-          source,
-          tap((x) => {
-            tapped.push(x);
-          }),
-          collectAll,
-        ),
-      ).rejects.toThrow('Source error');
-
-      expect(tapped).toEqual([1]);
-    });
-
-    it('should propagate errors after executing side effects', async () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.next(2);
-        sink.error(new Error('Error after values'));
-      };
-
-      const tapped: number[] = [];
-
-      await expect(
-        pipe(
-          source,
-          tap((x) => {
-            tapped.push(x);
-          }),
-          collectAll,
-        ),
-      ).rejects.toThrow('Error after values');
-
-      expect(tapped).toEqual([1, 2]);
     });
   });
 

--- a/packages/core/src/stream/operators/tap.ts
+++ b/packages/core/src/stream/operators/tap.ts
@@ -17,9 +17,6 @@ export const tap = <T>(fn: (value: T) => void): Operator<T> => {
           fn(value);
           sink.next(value);
         },
-        error(err) {
-          sink.error(err);
-        },
         complete() {
           sink.complete();
         },

--- a/packages/core/src/stream/pipe.test.ts
+++ b/packages/core/src/stream/pipe.test.ts
@@ -186,7 +186,6 @@ describe('pipe', () => {
             operations.push('op1');
             sink.next(v);
           },
-          error: (e) => sink.error(e),
           complete: () => sink.complete(),
         });
       };
@@ -198,7 +197,6 @@ describe('pipe', () => {
             operations.push('op2');
             sink.next(v);
           },
-          error: (e) => sink.error(e),
           complete: () => sink.complete(),
         });
       };
@@ -210,7 +208,6 @@ describe('pipe', () => {
             operations.push('op3');
             sink.next(v);
           },
-          error: (e) => sink.error(e),
           complete: () => sink.complete(),
         });
       };
@@ -229,7 +226,6 @@ describe('pipe', () => {
         src({
           start: (tb) => sink.start(tb),
           next: (v) => sink.next(v * 2),
-          error: (e) => sink.error(e),
           complete: () => sink.complete(),
         });
       };
@@ -246,7 +242,6 @@ describe('pipe', () => {
         src({
           start: (tb) => sink.start(tb),
           next: (v) => sink.next(v + 1),
-          error: (e) => sink.error(e),
           complete: () => sink.complete(),
         });
       };

--- a/packages/core/src/stream/sinks/collect-all.ts
+++ b/packages/core/src/stream/sinks/collect-all.ts
@@ -3,12 +3,11 @@ import type { Source } from '../types.ts';
 /**
  * Collects all values from a source into an array.
  * This is a terminal operator that accumulates all emitted values.
- * Rejects if the source emits an error.
  * @param source - The source to collect values from.
  * @returns A promise that resolves with an array of all emitted values.
  */
 export const collectAll = <T>(source: Source<T>): Promise<T[]> => {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     const results: T[] = [];
 
     source({
@@ -17,10 +16,6 @@ export const collectAll = <T>(source: Source<T>): Promise<T[]> => {
       },
       next(value) {
         results.push(value);
-      },
-      error(err) {
-        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-        reject(err);
       },
       complete() {
         resolve(results);

--- a/packages/core/src/stream/sinks/collect.ts
+++ b/packages/core/src/stream/sinks/collect.ts
@@ -3,7 +3,7 @@ import type { Source } from '../types.ts';
 /**
  * Collects the last value emitted by a source.
  * This is a terminal operator that returns the last emitted value.
- * Rejects if the source emits an error or completes without emitting any values.
+ * Rejects if the source completes without emitting any values.
  * @param source - The source to collect from.
  * @returns A promise that resolves with the last emitted value.
  */
@@ -19,10 +19,6 @@ export const collect = <T>(source: Source<T>): Promise<T> => {
       next(value) {
         lastValue = value;
         hasValue = true;
-      },
-      error(err) {
-        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-        reject(err);
       },
       complete() {
         if (hasValue) {

--- a/packages/core/src/stream/sinks/publish.test.ts
+++ b/packages/core/src/stream/sinks/publish.test.ts
@@ -55,7 +55,11 @@ describe('publish', () => {
     it('should consume after map', () => {
       const source = fromArray([1, 2, 3]);
 
-      const result = pipe(source, map((x) => x * 2), publish);
+      const result = pipe(
+        source,
+        map((x) => x * 2),
+        publish,
+      );
 
       expect(result).toBeUndefined();
     });
@@ -113,35 +117,6 @@ describe('publish', () => {
       publish(source);
 
       expect(emittedValues).toEqual([1, 2, 3, 4, 5]);
-    });
-  });
-
-  describe('error handling', () => {
-    it('should not throw on source error', () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.error(new Error('Source error'));
-      };
-
-      expect(() => publish(source)).not.toThrow();
-    });
-
-    it('should silently consume errors', () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.error(new Error('Should be ignored'));
-      };
-
-      const result = publish(source);
-
-      expect(result).toBeUndefined();
     });
   });
 

--- a/packages/core/src/stream/sinks/publish.ts
+++ b/packages/core/src/stream/sinks/publish.ts
@@ -6,7 +6,6 @@ export const publish = <T>(source: Source<T>): void => {
       talkback.pull();
     },
     next() {},
-    error() {},
     complete() {},
   });
 };

--- a/packages/core/src/stream/sinks/subscribe.test.ts
+++ b/packages/core/src/stream/sinks/subscribe.test.ts
@@ -5,7 +5,6 @@ import { fromValue } from '../sources/from-value.ts';
 import { pipe } from '../pipe.ts';
 import { map } from '../operators/map.ts';
 import { filter } from '../operators/filter.ts';
-import type { Sink } from '../types.ts';
 
 describe('subscribe', () => {
   describe('basic functionality', () => {
@@ -126,71 +125,6 @@ describe('subscribe', () => {
       );
 
       expect(completeCalls).toBe(1);
-    });
-
-    it('should call error on source error', () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.error(new Error('Test error'));
-      };
-
-      let errorReceived: Error | null = null;
-
-      pipe(
-        source,
-        subscribe({
-          error: (err) => {
-            errorReceived = err as Error;
-          },
-        }),
-      );
-
-      expect(errorReceived).not.toBeNull();
-      expect(errorReceived!.message).toBe('Test error');
-    });
-
-    it('should not call complete after error', () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.error(new Error('Error'));
-      };
-
-      let completed = false;
-
-      pipe(
-        source,
-        subscribe({
-          error: () => {},
-          complete: () => {
-            completed = true;
-          },
-        }),
-      );
-
-      expect(completed).toBe(false);
-    });
-
-    it('should not call error after complete', () => {
-      const source = fromArray([1, 2, 3]);
-      let errorCalled = false;
-
-      pipe(
-        source,
-        subscribe({
-          error: () => {
-            errorCalled = true;
-          },
-        }),
-      );
-
-      expect(errorCalled).toBe(false);
     });
   });
 
@@ -473,61 +407,6 @@ describe('subscribe', () => {
       );
 
       expect(values).toEqual(['', 'a', '']);
-    });
-  });
-
-  describe('error propagation', () => {
-    it('should receive errors from source', () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.next(1);
-        sink.error(new Error('Source error'));
-      };
-
-      const values: number[] = [];
-      let errorReceived: Error | null = null;
-
-      pipe(
-        source,
-        subscribe({
-          next: (value) => {
-            values.push(value);
-          },
-          error: (err) => {
-            errorReceived = err as Error;
-          },
-        }),
-      );
-
-      expect(values).toEqual([1]);
-      expect(errorReceived!.message).toBe('Source error');
-    });
-
-    it('should not call next after error', () => {
-      const source = (sink: Sink<number>) => {
-        sink.start({
-          pull: () => {},
-          cancel: () => {},
-        });
-        sink.error(new Error('Early error'));
-      };
-
-      let nextCalled = false;
-
-      pipe(
-        source,
-        subscribe({
-          next: () => {
-            nextCalled = true;
-          },
-          error: () => {},
-        }),
-      );
-
-      expect(nextCalled).toBe(false);
     });
   });
 

--- a/packages/core/src/stream/sinks/subscribe.ts
+++ b/packages/core/src/stream/sinks/subscribe.ts
@@ -14,12 +14,6 @@ export type Observer<T> = {
    * Called when the source completes.
    */
   complete?: () => void;
-
-  /**
-   * Called when an error occurs.
-   * @param error - The error that occurred.
-   */
-  error?: (error: unknown) => void;
 };
 
 /**
@@ -43,14 +37,6 @@ export const subscribe = <T>(observer: Observer<T>) => {
       next(value) {
         if (!closed && observer.next) {
           observer.next(value);
-        }
-      },
-      error(err) {
-        if (!closed) {
-          closed = true;
-          if (observer.error) {
-            observer.error(err);
-          }
         }
       },
       complete() {

--- a/packages/core/src/stream/sources/from-array.test.ts
+++ b/packages/core/src/stream/sources/from-array.test.ts
@@ -212,7 +212,6 @@ describe('fromArray', () => {
       source({
         start: () => {},
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -228,7 +227,6 @@ describe('fromArray', () => {
       source({
         start: () => {},
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -254,7 +252,6 @@ describe('fromArray', () => {
             talkback.cancel();
           }
         },
-        error: () => {},
         complete: () => {},
       });
 
@@ -273,7 +270,6 @@ describe('fromArray', () => {
         next: (value) => {
           emitted.push(value);
         },
-        error: () => {},
         complete: () => {},
       });
 
@@ -289,7 +285,6 @@ describe('fromArray', () => {
           tb.cancel();
         },
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -309,7 +304,6 @@ describe('fromArray', () => {
           receivedTalkback = tb;
         },
         next: () => {},
-        error: () => {},
         complete: () => {},
       });
 
@@ -326,7 +320,6 @@ describe('fromArray', () => {
           expect(() => tb.pull()).not.toThrow();
         },
         next: () => {},
-        error: () => {},
         complete: () => {},
       });
     });
@@ -435,7 +428,6 @@ describe('fromArray', () => {
         next: (value) => {
           emitted.push(value);
         },
-        error: () => {},
         complete: () => {},
       });
 
@@ -449,7 +441,6 @@ describe('fromArray', () => {
       source({
         start: () => {},
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -469,7 +460,6 @@ describe('fromArray', () => {
         next: (value) => {
           events.push(`next:${value}`);
         },
-        error: () => {},
         complete: () => {
           events.push('complete');
         },

--- a/packages/core/src/stream/sources/from-value.test.ts
+++ b/packages/core/src/stream/sources/from-value.test.ts
@@ -23,7 +23,6 @@ describe('fromValue', () => {
       source({
         start: () => {},
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -178,7 +177,6 @@ describe('fromValue', () => {
       source({
         start: () => {},
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -198,7 +196,6 @@ describe('fromValue', () => {
         next: (value) => {
           events.push(`next:${value}`);
         },
-        error: () => {},
         complete: () => {
           events.push('complete');
         },
@@ -220,7 +217,6 @@ describe('fromValue', () => {
         next: (value) => {
           emitted.push(value);
         },
-        error: () => {},
         complete: () => {},
       });
 
@@ -236,7 +232,6 @@ describe('fromValue', () => {
           tb.cancel();
         },
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },
@@ -256,7 +251,6 @@ describe('fromValue', () => {
           receivedTalkback = tb;
         },
         next: () => {},
-        error: () => {},
         complete: () => {},
       });
 
@@ -273,7 +267,6 @@ describe('fromValue', () => {
           expect(() => tb.pull()).not.toThrow();
         },
         next: () => {},
-        error: () => {},
         complete: () => {},
       });
     });
@@ -327,7 +320,6 @@ describe('fromValue', () => {
         next: (value) => {
           emitted.push(value);
         },
-        error: () => {},
         complete: () => {},
       });
 
@@ -341,7 +333,6 @@ describe('fromValue', () => {
       source({
         start: () => {},
         next: () => {},
-        error: () => {},
         complete: () => {
           completed = true;
         },

--- a/packages/core/src/stream/sources/make-subject.test.ts
+++ b/packages/core/src/stream/sources/make-subject.test.ts
@@ -29,13 +29,4 @@ describe('makeSubject', () => {
     expect(await promise2).toEqual([1, 2]);
   });
 
-  it('should handle error', async () => {
-    const subject = makeSubject<number>();
-    const promise = pipe(subject.source, collectAll);
-
-    subject.next(1);
-    subject.error(new Error('test'));
-
-    await expect(promise).rejects.toThrow('test');
-  });
 });

--- a/packages/core/src/stream/sources/make-subject.ts
+++ b/packages/core/src/stream/sources/make-subject.ts
@@ -16,12 +16,6 @@ export type Subject<T> = {
   next: (value: T) => void;
 
   /**
-   * Push an error to all subscribers and complete.
-   * @param error - The error to push.
-   */
-  error: (error: unknown) => void;
-
-  /**
    * Complete all subscribers.
    */
   complete: () => void;
@@ -54,13 +48,6 @@ export const makeSubject = <T>(): Subject<T> => {
     }
   };
 
-  const error = (err: unknown) => {
-    for (const sink of sinks) {
-      sink.error(err);
-    }
-    sinks.length = 0;
-  };
-
   const complete = () => {
     for (const sink of sinks) {
       sink.complete();
@@ -71,7 +58,6 @@ export const makeSubject = <T>(): Subject<T> => {
   return {
     source,
     next,
-    error,
     complete,
   };
 };

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -30,12 +30,6 @@ export type Sink<T> = {
   next(value: T): void;
 
   /**
-   * Receive an error and end the stream.
-   * @param error - The error that occurred.
-   */
-  error(error: unknown): void;
-
-  /**
    * Receive completion signal.
    */
   complete(): void;


### PR DESCRIPTION
Simplifies the stream implementation by removing error handling mechanism.

- Remove `error` method from `Sink<T>` interface
- Remove `error` method from `Subject<T>` interface
- Remove error propagation logic from all stream operators
- Remove all error-related test cases

This change simplifies the stream system while maintaining core functionality.