### PR TITLE
fix(core): fix various issues in exchange implementations

### DIFF
--- a/.changeset/fair-foxes-cheer.md
+++ b/.changeset/fair-foxes-cheer.md
@@ -1,0 +1,5 @@
+---
+'@mearie/core': patch
+---
+
+Fix stream sharing issues in exchanges to prevent duplicate subscriptions and improve cache policy handling

--- a/packages/core/src/exchanges/compose.ts
+++ b/packages/core/src/exchanges/compose.ts
@@ -1,4 +1,6 @@
 import type { Exchange, ExchangeIO } from '../exchange.ts';
+import { pipe } from '../stream/pipe.ts';
+import { share } from '../stream/operators/share.ts';
 
 export type ComposeExchangeOptions = {
   exchanges: Exchange[];
@@ -9,6 +11,10 @@ export const composeExchange = (options: ComposeExchangeOptions): Exchange => {
 
   return (forward) => {
     // eslint-disable-next-line unicorn/no-array-reduce
-    return exchanges.reduceRight<ExchangeIO>((forward, exchange) => exchange(forward), forward);
+    return exchanges.reduceRight<ExchangeIO>((forward, exchange) => {
+      return (ops$) => {
+        return pipe(ops$, share(), exchange(forward), share());
+      };
+    }, forward);
   };
 };

--- a/packages/core/src/exchanges/dedup.ts
+++ b/packages/core/src/exchanges/dedup.ts
@@ -3,6 +3,7 @@ import { pipe } from '../stream/pipe.ts';
 import { filter } from '../stream/operators/filter.ts';
 import { merge } from '../stream/operators/merge.ts';
 import { mergeMap } from '../stream/operators/merge-map.ts';
+import { delay } from '../stream/operators/delay.ts';
 import { fromArray } from '../stream/sources/from-array.ts';
 import { stringify } from '../utils.ts';
 import { fromValue } from '../stream/index.ts';
@@ -60,6 +61,7 @@ export const dedupExchange = (): Exchange => {
 
           return (op.metadata.dedup?.skip ?? false) || !isInflight;
         }),
+        delay(0),
         forward,
         mergeMap((result) => {
           if (result.operation.variant !== 'request') {

--- a/packages/core/src/exchanges/http.ts
+++ b/packages/core/src/exchanges/http.ts
@@ -115,13 +115,18 @@ export const httpExchange = (options: HttpOptions): Exchange => {
     return (ops$) => {
       const fetch$ = pipe(
         ops$,
-        filter((op): op is RequestOperation => op.variant === 'request' && op.artifact.kind !== 'fragment'),
+        filter(
+          (op): op is RequestOperation =>
+            op.variant === 'request' && (op.artifact.kind === 'query' || op.artifact.kind === 'mutation'),
+        ),
         mergeMap((op) => fromPromise(executeFetch(url, op, { mode, credentials, headers }))),
       );
 
       const forward$ = pipe(
         ops$,
-        filter((op) => op.variant === 'teardown' || op.artifact.kind !== 'fragment'),
+        filter(
+          (op) => op.variant === 'teardown' || op.artifact.kind === 'subscription' || op.artifact.kind === 'fragment',
+        ),
         forward,
       );
 

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -4,6 +4,7 @@ import { pipe } from '../stream/pipe.ts';
 import { filter } from '../stream/operators/filter.ts';
 import { mergeMap } from '../stream/operators/merge-map.ts';
 import { merge } from '../stream/operators/merge.ts';
+import { share } from '../stream/operators/share.ts';
 import { takeUntil } from '../stream/operators/take-until.ts';
 import { make } from '../stream/sources/make.ts';
 
@@ -68,6 +69,7 @@ export const subscriptionExchange = (options: SubscriptionExchangeOptions): Exch
       const teardowns$ = pipe(
         ops$,
         filter((op) => op.variant === 'teardown'),
+        share(),
       );
 
       const subscription$ = pipe(

--- a/packages/core/src/exchanges/terminal.ts
+++ b/packages/core/src/exchanges/terminal.ts
@@ -3,12 +3,14 @@ import { ExchangeError } from '../errors.ts';
 import { pipe } from '../stream/pipe.ts';
 import { mergeMap } from '../stream/operators/merge-map.ts';
 import { fromValue } from '../stream/sources/from-value.ts';
+import { filter } from '../stream/operators/filter.ts';
 
 export const terminalExchange = (): Exchange => {
   return () => {
     return (ops$) => {
       return pipe(
         ops$,
+        filter((op) => op.variant !== 'teardown'),
         mergeMap((op) =>
           fromValue({
             operation: op,


### PR DESCRIPTION
This PR fixes critical stream sharing issues in the exchange system that were causing duplicate subscriptions and incorrect cache behavior.

Key changes:
- Added share() operators in compose, cache, retry, and subscription exchanges to prevent duplicate subscriptions
- Fixed cache exchange logic to properly handle cache-and-network and cache-first fetch policies
- Added delay(0) in dedup exchange to prevent synchronous emission issues
- Improved retry exchange with proper teardown tracking and skip logic for mutations
- Fixed http exchange filtering for correct query/mutation operation handling
- Added teardown filtering in terminal exchange to prevent unnecessary processing