### PR TITLE
test(core): add comprehensive test suite for exchange system

### DIFF
--- a/packages/core/src/exchanges/cache.test.ts
+++ b/packages/core/src/exchanges/cache.test.ts
@@ -1,0 +1,468 @@
+import { describe, it, expect } from 'vitest';
+import { cacheExchange } from './cache.ts';
+import { makeTestOperation, makeTestForward, testExchange } from './test-utils.ts';
+import type { SchemaMeta } from '@mearie/shared';
+import type { Operation } from '../exchange.ts';
+
+const schema: SchemaMeta = {
+  entities: {
+    User: { keyFields: ['id'] },
+    Post: { keyFields: ['id'] },
+  },
+};
+
+describe('cacheExchange', () => {
+  describe('fetch policies', () => {
+    describe('cache-first', () => {
+      it('should return cached data if available', async () => {
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'cache-first' });
+        const forward = makeTestForward((op) => ({
+          operation: op,
+          data: { user: { id: '1', name: 'Alice' } },
+        }));
+        const operation = makeTestOperation({ kind: 'query', name: 'GetUser' });
+
+        const results1 = await testExchange(exchange, forward, [operation]);
+        const results2 = await testExchange(exchange, forward, [operation]);
+
+        expect(results1).toHaveLength(1);
+        expect(results2).toHaveLength(1);
+      });
+
+      it('should forward to network if cache miss', async () => {
+        const forwardedOps: Operation[] = [];
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'cache-first' });
+        const forward = makeTestForward((op) => {
+          forwardedOps.push(op);
+          return { operation: op, data: { test: true } };
+        });
+        const operation = makeTestOperation({
+          kind: 'query',
+          selections: [{ kind: 'Field', name: 'test' }],
+        });
+
+        await testExchange(exchange, forward, [operation]);
+
+        expect(forwardedOps.length).toBeGreaterThan(0);
+      });
+
+      it('should not forward if cache hit', async () => {
+        const forwardedOps: Operation[] = [];
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'cache-first' });
+        const forward = makeTestForward((op) => {
+          forwardedOps.push(op);
+          return { operation: op, data: { test: true } };
+        });
+        const operation = makeTestOperation({ kind: 'query', name: 'GetData' });
+
+        await testExchange(exchange, forward, [operation]);
+        forwardedOps.length = 0;
+
+        await testExchange(exchange, forward, [operation]);
+
+        expect(forwardedOps).toHaveLength(0);
+      });
+    });
+
+    describe('cache-and-network', () => {
+      it('should return cached data immediately', async () => {
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'cache-and-network' });
+        const forward = makeTestForward((op) => ({
+          operation: op,
+          data: { test: true },
+        }));
+        const operation = makeTestOperation({
+          kind: 'query',
+          selections: [{ kind: 'Field', name: 'test' }],
+        });
+
+        const results1 = await testExchange(exchange, forward, [operation]);
+        const results2 = await testExchange(exchange, forward, [operation]);
+
+        expect(results1).toHaveLength(1);
+        expect(results2.length).toBeGreaterThan(0);
+      });
+
+      it('should forward to network always', async () => {
+        const forwardedOps: Operation[] = [];
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'cache-and-network' });
+        const forward = makeTestForward((op) => {
+          forwardedOps.push(op);
+          return { operation: op, data: { test: true } };
+        });
+        const operation = makeTestOperation({ kind: 'query', name: 'GetData' });
+
+        await testExchange(exchange, forward, [operation]);
+        const count1 = forwardedOps.length;
+        await testExchange(exchange, forward, [operation]);
+        const count2 = forwardedOps.length;
+
+        expect(count2).toBeGreaterThan(count1);
+      });
+
+      it('should emit cache data then network data', async () => {
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'cache-and-network' });
+        const forward = makeTestForward((op) => ({
+          operation: op,
+          data: { network: true },
+        }));
+        const operation = makeTestOperation({ kind: 'query', name: 'GetData' });
+
+        await testExchange(exchange, forward, [operation]);
+        const results = await testExchange(exchange, forward, [operation]);
+
+        expect(results.length).toBeGreaterThan(0);
+      });
+    });
+
+    describe('network-only', () => {
+      it('should always forward to network', async () => {
+        const forwardedOps: Operation[] = [];
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'network-only' });
+        const forward = makeTestForward((op) => {
+          forwardedOps.push(op);
+          return { operation: op, data: { test: true } };
+        });
+        const operation = makeTestOperation({ kind: 'query', name: 'GetData' });
+
+        await testExchange(exchange, forward, [operation]);
+        const count1 = forwardedOps.length;
+        await testExchange(exchange, forward, [operation]);
+        const count2 = forwardedOps.length;
+
+        expect(count2).toBeGreaterThan(count1);
+      });
+
+      it('should not read from cache', async () => {
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'network-only' });
+        const forward = makeTestForward((op) => ({
+          operation: op,
+          data: { network: true },
+        }));
+        const operation = makeTestOperation({ kind: 'query' });
+
+        const results = await testExchange(exchange, forward, [operation]);
+
+        expect(results).toHaveLength(1);
+        expect(results[0].data).toEqual({ network: true });
+      });
+
+      it('should write network response to cache', async () => {
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'network-only' });
+        const forward = makeTestForward((op) => ({
+          operation: op,
+          data: { test: true },
+        }));
+        const operation = makeTestOperation({ kind: 'query', name: 'GetData' });
+
+        await testExchange(exchange, forward, [operation]);
+        const cache = exchange.cache;
+
+        expect(cache).toBeDefined();
+      });
+    });
+
+    describe('cache-only', () => {
+      it('should return cached data only', async () => {
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'cache-only' });
+        const forward = makeTestForward((op) => ({
+          operation: op,
+          data: { test: true },
+        }));
+        const operation = makeTestOperation({ kind: 'query', name: 'GetData' });
+
+        await testExchange(exchange, forward, [operation]);
+
+        const forwardedOps: Operation[] = [];
+        const forward2 = makeTestForward((op) => {
+          forwardedOps.push(op);
+          return { operation: op };
+        });
+        const exchange2 = cacheExchange({ schemaMeta: schema, fetchPolicy: 'cache-only' });
+        await testExchange(exchange2, forward2, [operation]);
+
+        expect(forwardedOps).toHaveLength(0);
+      });
+
+      it('should not forward to network', async () => {
+        const forwardedOps: Operation[] = [];
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'cache-only' });
+        const forward = makeTestForward((op) => {
+          forwardedOps.push(op);
+          return { operation: op, data: { test: true } };
+        });
+        const operation = makeTestOperation({ kind: 'query' });
+
+        await testExchange(exchange, forward, [operation]);
+
+        expect(forwardedOps).toHaveLength(0);
+      });
+
+      it('should return null if cache miss', async () => {
+        const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'cache-only' });
+        const forward = makeTestForward();
+        const operation = makeTestOperation({
+          kind: 'query',
+          selections: [{ kind: 'Field', name: 'test' }],
+        });
+
+        const results = await testExchange(exchange, forward, [operation]);
+
+        expect(results[0].data).toBeNull();
+      });
+    });
+  });
+
+  describe('query operations', () => {
+    it('should read query from cache', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { test: true },
+      }));
+      const operation = makeTestOperation({ kind: 'query', name: 'GetData' });
+
+      await testExchange(exchange, forward, [operation]);
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].data).toBeDefined();
+    });
+
+    it('should subscribe to query updates', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { count: 1 },
+      }));
+      const operation = makeTestOperation({ kind: 'query', name: 'GetCount' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+    });
+
+    it('should write query result to cache', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { test: true },
+      }));
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(exchange.cache).toBeDefined();
+    });
+
+    it('should handle cache misses', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema, fetchPolicy: 'cache-first' });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { test: true },
+      }));
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+    });
+  });
+
+  describe('fragment operations', () => {
+    it('should read fragment from cache', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward();
+      const fragmentRef = { __key: 'User:1', __typename: 'User' };
+      const operation = makeTestOperation({
+        kind: 'fragment',
+        metadata: { fragmentRef },
+      });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+    });
+
+    it('should subscribe to fragment updates', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward();
+      const fragmentRef = { __key: 'User:1', __typename: 'User' };
+      const operation = makeTestOperation({
+        kind: 'fragment',
+        metadata: { fragmentRef },
+      });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+    });
+
+    it('should require fragmentRef in metadata', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'fragment' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].errors).toBeDefined();
+    });
+
+    it('should error if fragmentRef missing', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'fragment' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].errors).toHaveLength(1);
+      expect(results[0].errors![0].message).toContain('fragmentRef');
+    });
+  });
+
+  describe('mutation operations', () => {
+    it('should forward mutations', async () => {
+      const forwardedOps: Operation[] = [];
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op, data: { success: true } };
+      });
+      const operation = makeTestOperation({ kind: 'mutation' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+    });
+
+    it('should write mutation result to cache', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { createUser: { id: '1', name: 'Alice' } },
+      }));
+      const operation = makeTestOperation({ kind: 'mutation' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(exchange.cache).toBeDefined();
+    });
+
+    it('should not read from cache for mutations', async () => {
+      const forwardedOps: Operation[] = [];
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op, data: { test: true } };
+      });
+      const operation = makeTestOperation({ kind: 'mutation' });
+
+      await testExchange(exchange, forward, [operation]);
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(2);
+    });
+  });
+
+  describe('subscription operations', () => {
+    it('should forward subscriptions', async () => {
+      const forwardedOps: Operation[] = [];
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op, data: { test: true } };
+      });
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+    });
+
+    it('should write subscription data to cache', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { message: 'Hello' },
+      }));
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(exchange.cache).toBeDefined();
+    });
+  });
+
+  describe('teardown handling', () => {
+    it('should stop cache subscription on teardown', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { test: true },
+      }));
+      const operation = makeTestOperation({ kind: 'query', key: 'test-1' });
+      const teardown = makeTestOperation({ variant: 'teardown', key: 'test-1' });
+
+      const results = await testExchange(exchange, forward, [operation, teardown]);
+
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('should forward teardown operations', async () => {
+      const forwardedOps: Operation[] = [];
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ variant: 'teardown' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+    });
+  });
+
+  describe('cache updates', () => {
+    it('should emit new data when cache updates', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { count: 1 },
+      }));
+      const operation = makeTestOperation({ kind: 'query', name: 'GetCount' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+    });
+
+    it('should update all subscribers of same query', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { test: true },
+      }));
+      const op1 = makeTestOperation({ kind: 'query', name: 'GetData', variables: {} });
+      const op2 = makeTestOperation({ kind: 'query', name: 'GetData', variables: {} });
+
+      const results = await testExchange(exchange, forward, [op1, op2]);
+
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    it('should update fragment subscribers when entity changes', async () => {
+      const exchange = cacheExchange({ schemaMeta: schema });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { user: { id: '1', name: 'Alice' } },
+      }));
+      const fragmentRef = { __key: 'User:1', __typename: 'User' };
+      const fragment = makeTestOperation({ kind: 'fragment', metadata: { fragmentRef } });
+      const query = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [fragment, query]);
+
+      expect(results.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/core/src/exchanges/compose.test.ts
+++ b/packages/core/src/exchanges/compose.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect } from 'vitest';
+import { composeExchange } from './compose.ts';
+import { makeTestOperation, makeTestForward, testExchange } from './test-utils.ts';
+import type { Exchange, Operation } from '../exchange.ts';
+import { pipe } from '../stream/pipe.ts';
+import { map } from '../stream/operators/map.ts';
+import { filter } from '../stream/operators/filter.ts';
+import { merge } from '../stream/operators/merge.ts';
+import { mergeMap } from '../stream/operators/merge-map.ts';
+import { fromArray } from '../stream/sources/from-array.ts';
+import { subscribe } from '../stream/sinks/subscribe.ts';
+
+describe('composeExchange', () => {
+  describe('basic composition', () => {
+    it('should compose single exchange', async () => {
+      const exchange1: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          forward,
+          map((result) => ({ ...result, data: { value: 1 } })),
+        );
+
+      const composed = composeExchange({ exchanges: [exchange1] });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(composed, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].data).toEqual({ value: 1 });
+    });
+
+    it('should compose two exchanges', async () => {
+      const exchange1: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          forward,
+          map((result) => ({
+            ...result,
+            data: { ...result.data, first: true },
+          })),
+        );
+
+      const exchange2: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          forward,
+          map((result) => ({
+            ...result,
+            data: { ...result.data, second: true },
+          })),
+        );
+
+      const composed = composeExchange({ exchanges: [exchange1, exchange2] });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(composed, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].data).toEqual({ first: true, second: true });
+    });
+
+    it('should compose three exchanges', async () => {
+      const exchange1: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          forward,
+          map((result) => ({
+            ...result,
+            data: { ...result.data, first: true },
+          })),
+        );
+
+      const exchange2: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          forward,
+          map((result) => ({
+            ...result,
+            data: { ...result.data, second: true },
+          })),
+        );
+
+      const exchange3: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          forward,
+          map((result) => ({
+            ...result,
+            data: { ...result.data, third: true },
+          })),
+        );
+
+      const composed = composeExchange({ exchanges: [exchange1, exchange2, exchange3] });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(composed, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].data).toEqual({ first: true, second: true, third: true });
+    });
+
+    it('should handle empty exchanges array', async () => {
+      const composed = composeExchange({ exchanges: [] });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { empty: true },
+      }));
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(composed, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].data).toEqual({ empty: true });
+    });
+  });
+
+  describe('execution order', () => {
+    it('should apply exchanges in correct order', async () => {
+      const order: number[] = [];
+
+      const exchange1: Exchange = (forward) => (ops$) => {
+        order.push(1);
+        return pipe(ops$, forward);
+      };
+
+      const exchange2: Exchange = (forward) => (ops$) => {
+        order.push(2);
+        return pipe(ops$, forward);
+      };
+
+      const exchange3: Exchange = (forward) => (ops$) => {
+        order.push(3);
+        return pipe(ops$, forward);
+      };
+
+      const composed = composeExchange({ exchanges: [exchange1, exchange2, exchange3] });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(composed, forward, [operation]);
+
+      expect(order).toEqual([1, 2, 3]);
+    });
+
+    it('should pass operations through exchange chain', async () => {
+      const operationsSeen: Operation[][] = [[], [], []];
+
+      const exchange1: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          map((op) => {
+            if (op.variant === 'request') {
+              operationsSeen[0].push(op);
+            }
+            return op;
+          }),
+          forward,
+        );
+
+      const exchange2: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          map((op) => {
+            if (op.variant === 'request') {
+              operationsSeen[1].push(op);
+            }
+            return op;
+          }),
+          forward,
+        );
+
+      const exchange3: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          map((op) => {
+            if (op.variant === 'request') {
+              operationsSeen[2].push(op);
+            }
+            return op;
+          }),
+          forward,
+        );
+
+      const composed = composeExchange({ exchanges: [exchange1, exchange2, exchange3] });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(composed, forward, [operation]);
+
+      expect(operationsSeen[0]).toHaveLength(1);
+      expect(operationsSeen[1]).toHaveLength(1);
+      expect(operationsSeen[2]).toHaveLength(1);
+      expect(operationsSeen[0][0]).toEqual(operation);
+      expect(operationsSeen[1][0]).toEqual(operation);
+      expect(operationsSeen[2][0]).toEqual(operation);
+    });
+
+    it('should allow each exchange to transform operations', async () => {
+      const exchange1: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          map((op) => ({ ...op, metadata: { ...op.metadata, ex1: true } })),
+          forward,
+        );
+
+      const exchange2: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          map((op) => ({ ...op, metadata: { ...op.metadata, ex2: true } })),
+          forward,
+        );
+
+      const composed = composeExchange({ exchanges: [exchange1, exchange2] });
+
+      let finalOperation: Operation | undefined;
+      const forward = makeTestForward((op) => {
+        finalOperation = op;
+        return { operation: op };
+      });
+
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(composed, forward, [operation]);
+
+      expect(finalOperation?.metadata.ex1).toBe(true);
+      expect(finalOperation?.metadata.ex2).toBe(true);
+    });
+  });
+
+  describe('forward function', () => {
+    it('should pass forward to innermost exchange', async () => {
+      let forwardCallCount = 0;
+
+      const exchange1: Exchange = (forward) => (ops$) => {
+        forwardCallCount++;
+        return pipe(ops$, forward);
+      };
+
+      const composed = composeExchange({ exchanges: [exchange1] });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(composed, forward, [operation]);
+
+      expect(forwardCallCount).toBe(1);
+    });
+
+    it('should call forward from last exchange in chain', async () => {
+      let lastForwardCalled = false;
+
+      const exchange1: Exchange = (forward) => (ops$) => pipe(ops$, forward);
+
+      const exchange2: Exchange = (forward) => (ops$) => pipe(ops$, forward);
+
+      const composed = composeExchange({ exchanges: [exchange1, exchange2] });
+      const forward = makeTestForward(() => {
+        lastForwardCalled = true;
+        return {};
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(composed, forward, [operation]);
+
+      expect(lastForwardCalled).toBe(true);
+    });
+  });
+
+  describe('result flow', () => {
+    it('should allow exchanges to modify results on the way back', async () => {
+      const exchange1: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          forward,
+          map((result) => ({
+            ...result,
+            data: { ...result.data, modified1: true },
+          })),
+        );
+
+      const exchange2: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          forward,
+          map((result) => ({
+            ...result,
+            data: { ...result.data, modified2: true },
+          })),
+        );
+
+      const composed = composeExchange({ exchanges: [exchange1, exchange2] });
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { original: true },
+      }));
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(composed, forward, [operation]);
+
+      expect(results[0].data).toEqual({
+        original: true,
+        modified2: true,
+        modified1: true,
+      });
+    });
+  });
+
+  describe('share() isolation', () => {
+    it('should isolate upstream exchanges from downstream multiple subscriptions (input share)', async () => {
+      let exchange1ExecutionCount = 0;
+
+      const exchange1: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          map((op) => {
+            exchange1ExecutionCount++;
+            return op;
+          }),
+          forward,
+        );
+
+      const exchange2: Exchange = (forward) => (ops$) => {
+        const stream1$ = pipe(ops$, forward);
+        const stream2$ = pipe(ops$, forward);
+        const stream3$ = pipe(ops$, forward);
+
+        return pipe(
+          ops$,
+          mergeMap(() => merge(stream1$, stream2$, stream3$)),
+        );
+      };
+
+      const composed = composeExchange({ exchanges: [exchange1, exchange2] });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(composed, forward, [operation]);
+
+      expect(exchange1ExecutionCount).toBe(1);
+    });
+
+    it('should isolate exchanges from multiple result subscribers (output share)', async () => {
+      let exchange1ExecutionCount = 0;
+
+      const exchange1: Exchange = (forward) => (ops$) =>
+        pipe(
+          ops$,
+          map((op) => {
+            exchange1ExecutionCount++;
+            return op;
+          }),
+          forward,
+        );
+
+      const composed = composeExchange({ exchanges: [exchange1] });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results: Operation[][] = [[], [], []];
+
+      const ops$ = fromArray([operation]);
+      const composed$ = composed(forward)(ops$);
+
+      pipe(
+        composed$,
+        subscribe({
+          next: (result) => {
+            results[0].push(result.operation);
+          },
+        }),
+      );
+
+      pipe(
+        composed$,
+        subscribe({
+          next: (result) => {
+            results[1].push(result.operation);
+          },
+        }),
+      );
+
+      pipe(
+        composed$,
+        subscribe({
+          next: (result) => {
+            results[2].push(result.operation);
+          },
+        }),
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(exchange1ExecutionCount).toBe(1);
+      expect(results[0]).toHaveLength(1);
+      expect(results[1]).toHaveLength(1);
+      expect(results[2]).toHaveLength(1);
+    });
+  });
+});

--- a/packages/core/src/exchanges/dedup.test.ts
+++ b/packages/core/src/exchanges/dedup.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect } from 'vitest';
+import { dedupExchange } from './dedup.ts';
+import { makeTestOperation, makeTestForward, testExchange } from './test-utils.ts';
+import type { Operation } from '../exchange.ts';
+
+describe('dedupExchange', () => {
+  describe('basic deduplication', () => {
+    it('should deduplicate identical queries', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op, data: { test: true } };
+      });
+
+      const op1 = makeTestOperation({ name: 'GetUser', variables: { id: 1 } });
+      const op2 = makeTestOperation({ name: 'GetUser', variables: { id: 1 } });
+
+      const results = await testExchange(exchange, forward, [op1, op2]);
+
+      expect(forwardedOps).toHaveLength(1);
+      expect(results).toHaveLength(2);
+      expect(results[0].data).toEqual({ test: true });
+      expect(results[1].data).toEqual({ test: true });
+    });
+
+    it('should not deduplicate different queries', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op, data: { test: true } };
+      });
+
+      const op1 = makeTestOperation({ name: 'GetUser', variables: { id: 1 } });
+      const op2 = makeTestOperation({ name: 'GetUser', variables: { id: 2 } });
+
+      await testExchange(exchange, forward, [op1, op2]);
+
+      expect(forwardedOps).toHaveLength(2);
+    });
+
+    it('should not deduplicate mutations', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op, data: { test: true } };
+      });
+
+      const op1 = makeTestOperation({ kind: 'mutation', name: 'CreateUser', variables: { name: 'Alice' } });
+      const op2 = makeTestOperation({ kind: 'mutation', name: 'CreateUser', variables: { name: 'Alice' } });
+
+      await testExchange(exchange, forward, [op1, op2]);
+
+      expect(forwardedOps).toHaveLength(2);
+    });
+  });
+
+  describe('dedup key generation', () => {
+    it('should treat same name and variables as duplicate', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({ name: 'GetPosts', variables: { limit: 10 } });
+      const op2 = makeTestOperation({ name: 'GetPosts', variables: { limit: 10 } });
+
+      await testExchange(exchange, forward, [op1, op2]);
+
+      expect(forwardedOps).toHaveLength(1);
+    });
+
+    it('should treat different names as different', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({ name: 'GetUser', variables: {} });
+      const op2 = makeTestOperation({ name: 'GetPost', variables: {} });
+
+      await testExchange(exchange, forward, [op1, op2]);
+
+      expect(forwardedOps).toHaveLength(2);
+    });
+
+    it('should treat different variables as different', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({ name: 'GetUser', variables: { id: '1' } });
+      const op2 = makeTestOperation({ name: 'GetUser', variables: { id: '2' } });
+
+      await testExchange(exchange, forward, [op1, op2]);
+
+      expect(forwardedOps).toHaveLength(2);
+    });
+
+    it('should handle empty variables', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({ name: 'GetPosts', variables: {} });
+      const op2 = makeTestOperation({ name: 'GetPosts', variables: {} });
+
+      await testExchange(exchange, forward, [op1, op2]);
+
+      expect(forwardedOps).toHaveLength(1);
+    });
+  });
+
+  describe('result distribution', () => {
+    it('should send result to all deduplicated operations', async () => {
+      const exchange = dedupExchange();
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { id: '1', name: 'Alice' },
+      }));
+
+      const op1 = makeTestOperation({ name: 'GetUser', variables: { id: 1 } });
+      const op2 = makeTestOperation({ name: 'GetUser', variables: { id: 1 } });
+      const op3 = makeTestOperation({ name: 'GetUser', variables: { id: 1 } });
+
+      const results = await testExchange(exchange, forward, [op1, op2, op3]);
+
+      expect(results).toHaveLength(3);
+      expect(results[0].data).toEqual({ id: '1', name: 'Alice' });
+      expect(results[1].data).toEqual({ id: '1', name: 'Alice' });
+      expect(results[2].data).toEqual({ id: '1', name: 'Alice' });
+    });
+
+    it('should preserve original operation keys in results', async () => {
+      const exchange = dedupExchange();
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { test: true },
+      }));
+
+      const op1 = makeTestOperation({ name: 'GetUser', variables: { id: 1 }, key: 'op-1' });
+      const op2 = makeTestOperation({ name: 'GetUser', variables: { id: 1 }, key: 'op-2' });
+      const op3 = makeTestOperation({ name: 'GetUser', variables: { id: 1 }, key: 'op-3' });
+
+      const results = await testExchange(exchange, forward, [op1, op2, op3]);
+
+      expect(results).toHaveLength(3);
+      expect(results[0].operation.key).toBe('op-1');
+      expect(results[1].operation.key).toBe('op-2');
+      expect(results[2].operation.key).toBe('op-3');
+    });
+  });
+
+  describe('teardown handling', () => {
+    it('should forward teardown when all subscribers torn down', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({ name: 'GetUser', variables: { id: 1 }, key: 'op-1' });
+      const teardown1 = makeTestOperation({ variant: 'teardown', key: 'op-1' });
+
+      await testExchange(exchange, forward, [op1, teardown1]);
+
+      const teardowns = forwardedOps.filter((op) => op.variant === 'teardown');
+      expect(teardowns).toHaveLength(1);
+    });
+
+    it('should not forward teardown while subscribers remain', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({ name: 'GetUser', variables: { id: 1 }, key: 'op-1' });
+      const op2 = makeTestOperation({ name: 'GetUser', variables: { id: 1 }, key: 'op-2' });
+      const teardown1 = makeTestOperation({ variant: 'teardown', key: 'op-1' });
+
+      await testExchange(exchange, forward, [op1, op2, teardown1]);
+
+      const teardowns = forwardedOps.filter((op) => op.variant === 'teardown');
+      expect(teardowns).toHaveLength(0);
+    });
+
+    it('should track multiple subscribers per operation', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({ name: 'GetUser', variables: { id: 1 }, key: 'op-1' });
+      const op2 = makeTestOperation({ name: 'GetUser', variables: { id: 1 }, key: 'op-2' });
+      const op3 = makeTestOperation({ name: 'GetUser', variables: { id: 1 }, key: 'op-3' });
+      const teardown1 = makeTestOperation({ variant: 'teardown', key: 'op-1' });
+      const teardown2 = makeTestOperation({ variant: 'teardown', key: 'op-2' });
+      const teardown3 = makeTestOperation({ variant: 'teardown', key: 'op-3' });
+
+      await testExchange(exchange, forward, [op1, op2, op3, teardown1, teardown2, teardown3]);
+
+      const teardowns = forwardedOps.filter((op) => op.variant === 'teardown');
+      expect(teardowns).toHaveLength(1);
+    });
+  });
+
+  describe('skip deduplication', () => {
+    it('should skip dedup when metadata.dedup.skip is true', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({
+        name: 'GetUser',
+        variables: { id: 1 },
+        metadata: { dedup: { skip: true } },
+      });
+      const op2 = makeTestOperation({
+        name: 'GetUser',
+        variables: { id: 1 },
+        metadata: { dedup: { skip: true } },
+      });
+
+      await testExchange(exchange, forward, [op1, op2]);
+
+      expect(forwardedOps).toHaveLength(2);
+    });
+  });
+
+  describe('operation forwarding', () => {
+    it('should forward only one operation for duplicates', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({ name: 'GetUser', variables: { id: 1 } });
+      const op2 = makeTestOperation({ name: 'GetUser', variables: { id: 1 } });
+      const op3 = makeTestOperation({ name: 'GetUser', variables: { id: 1 } });
+
+      await testExchange(exchange, forward, [op1, op2, op3]);
+
+      const requests = forwardedOps.filter((op) => op.variant === 'request');
+      expect(requests).toHaveLength(1);
+    });
+
+    it('should forward all mutations', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({ kind: 'mutation', name: 'CreateUser' });
+      const op2 = makeTestOperation({ kind: 'mutation', name: 'CreateUser' });
+      const op3 = makeTestOperation({ kind: 'mutation', name: 'CreateUser' });
+
+      await testExchange(exchange, forward, [op1, op2, op3]);
+
+      const mutations = forwardedOps.filter(
+        (op) => op.variant === 'request' && 'artifact' in op && op.artifact.kind === 'mutation',
+      );
+      expect(mutations).toHaveLength(3);
+    });
+
+    it('should forward subscriptions', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({ kind: 'subscription', name: 'OnUserUpdated' });
+      const op2 = makeTestOperation({ kind: 'subscription', name: 'OnUserUpdated' });
+
+      await testExchange(exchange, forward, [op1, op2]);
+
+      const subscriptions = forwardedOps.filter(
+        (op) => op.variant === 'request' && 'artifact' in op && op.artifact.kind === 'subscription',
+      );
+      expect(subscriptions).toHaveLength(1);
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('should handle mixed operation types', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const query1 = makeTestOperation({ kind: 'query', name: 'GetUser', variables: { id: 1 } });
+      const query2 = makeTestOperation({ kind: 'query', name: 'GetUser', variables: { id: 1 } });
+      const mutation = makeTestOperation({ kind: 'mutation', name: 'CreateUser' });
+      const subscription = makeTestOperation({ kind: 'subscription', name: 'OnUserUpdated' });
+
+      await testExchange(exchange, forward, [query1, query2, mutation, subscription]);
+
+      expect(forwardedOps).toHaveLength(3);
+    });
+
+    it('should handle multiple different operations', async () => {
+      const exchange = dedupExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+
+      const op1 = makeTestOperation({ name: 'GetUser', variables: { id: 1 } });
+      const op2 = makeTestOperation({ name: 'GetUser', variables: { id: 1 } });
+      const op3 = makeTestOperation({ name: 'GetUser', variables: { id: 2 } });
+      const op4 = makeTestOperation({ name: 'GetPost', variables: { id: 1 } });
+
+      await testExchange(exchange, forward, [op1, op2, op3, op4]);
+
+      expect(forwardedOps).toHaveLength(3);
+    });
+  });
+});

--- a/packages/core/src/exchanges/fragment.test.ts
+++ b/packages/core/src/exchanges/fragment.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from 'vitest';
+import { fragmentExchange } from './fragment.ts';
+import { makeTestOperation, makeTestForward, testExchange } from './test-utils.ts';
+import { isExchangeError } from '../errors.ts';
+import type { Operation } from '../exchange.ts';
+
+describe('fragmentExchange', () => {
+  describe('fragment operations', () => {
+    it('should return fragmentRef for fragment operation', async () => {
+      const exchange = fragmentExchange();
+      const forward = makeTestForward();
+      const fragmentRef = { __key: 'User:1', __typename: 'User' };
+      const operation = makeTestOperation({
+        kind: 'fragment',
+        metadata: { fragmentRef },
+      });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].data).toEqual(fragmentRef);
+      expect(results[0].errors).toBeUndefined();
+    });
+
+    it('should forward non-fragment operations', async () => {
+      const exchange = fragmentExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op, data: { test: true } };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+      expect(results).toHaveLength(1);
+      expect(results[0].data).toEqual({ test: true });
+    });
+
+    it('should forward teardown operations', async () => {
+      const exchange = fragmentExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ variant: 'teardown' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+      expect(forwardedOps[0]).toEqual(operation);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should error when fragmentRef missing in metadata', async () => {
+      const exchange = fragmentExchange();
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'fragment' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].errors).toBeDefined();
+      expect(results[0].errors).toHaveLength(1);
+      expect(results[0].data).toBeUndefined();
+    });
+
+    it('should include correct error message', async () => {
+      const exchange = fragmentExchange();
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'fragment' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      const error = results[0].errors![0];
+      expect(error.message).toBe(
+        'Fragment operation missing fragmentRef in metadata. This usually happens when the wrong fragment reference was passed.',
+      );
+    });
+
+    it('should set exchangeName to fragment', async () => {
+      const exchange = fragmentExchange();
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'fragment' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      const error = results[0].errors![0];
+      expect(isExchangeError(error, 'fragment')).toBe(true);
+    });
+  });
+
+  describe('operation filtering', () => {
+    it('should process only fragment operations', async () => {
+      const exchange = fragmentExchange();
+      const forward = makeTestForward();
+      const fragmentRef = { __key: 'User:1', __typename: 'User' };
+      const fragmentOp = makeTestOperation({
+        kind: 'fragment',
+        metadata: { fragmentRef },
+      });
+      const queryOp = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [fragmentOp, queryOp]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].data).toEqual(fragmentRef);
+    });
+
+    it('should not call forward for fragment operations', async () => {
+      const exchange = fragmentExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const fragmentRef = { __key: 'User:1', __typename: 'User' };
+      const operation = makeTestOperation({
+        kind: 'fragment',
+        metadata: { fragmentRef },
+      });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(0);
+    });
+
+    it('should call forward for queries', async () => {
+      const exchange = fragmentExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+      expect(forwardedOps[0].variant).toBe('request');
+    });
+
+    it('should call forward for mutations', async () => {
+      const exchange = fragmentExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ kind: 'mutation' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+      expect(forwardedOps[0].variant).toBe('request');
+    });
+
+    it('should call forward for subscriptions', async () => {
+      const exchange = fragmentExchange();
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+      expect(forwardedOps[0].variant).toBe('request');
+    });
+  });
+
+  describe('fragmentRef types', () => {
+    it('should handle fragmentRef with different properties', async () => {
+      const exchange = fragmentExchange();
+      const forward = makeTestForward();
+      const fragmentRef = {
+        __key: 'Post:42',
+        __typename: 'Post',
+        id: '42',
+      };
+      const operation = makeTestOperation({
+        kind: 'fragment',
+        metadata: { fragmentRef },
+      });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].data).toEqual(fragmentRef);
+    });
+
+    it('should handle fragmentRef with null key', async () => {
+      const exchange = fragmentExchange();
+      const forward = makeTestForward();
+      const fragmentRef = { __key: null, __typename: 'User' };
+      const operation = makeTestOperation({
+        kind: 'fragment',
+        metadata: { fragmentRef },
+      });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].data).toEqual(fragmentRef);
+    });
+  });
+
+  describe('multiple operations', () => {
+    it('should handle multiple fragment operations', async () => {
+      const exchange = fragmentExchange();
+      const forward = makeTestForward();
+      const ref1 = { __key: 'User:1', __typename: 'User' };
+      const ref2 = { __key: 'Post:1', __typename: 'Post' };
+      const op1 = makeTestOperation({ kind: 'fragment', metadata: { fragmentRef: ref1 } });
+      const op2 = makeTestOperation({ kind: 'fragment', metadata: { fragmentRef: ref2 } });
+
+      const results = await testExchange(exchange, forward, [op1, op2]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].data).toEqual(ref1);
+      expect(results[1].data).toEqual(ref2);
+    });
+
+    it('should handle mixed operations', async () => {
+      const exchange = fragmentExchange();
+      const forward = makeTestForward((op) => ({
+        operation: op,
+        data: { forwarded: true },
+      }));
+      const fragmentRef = { __key: 'User:1', __typename: 'User' };
+      const fragmentOp = makeTestOperation({
+        kind: 'fragment',
+        metadata: { fragmentRef },
+      });
+      const queryOp = makeTestOperation({ kind: 'query' });
+      const teardownOp = makeTestOperation({ variant: 'teardown' });
+
+      const results = await testExchange(exchange, forward, [fragmentOp, queryOp, teardownOp]);
+
+      expect(results).toHaveLength(3);
+      expect(results[0].data).toEqual(fragmentRef);
+      expect(results[1].data).toEqual({ forwarded: true });
+      expect(results[2].data).toEqual({ forwarded: true });
+    });
+  });
+});

--- a/packages/core/src/exchanges/http.test.ts
+++ b/packages/core/src/exchanges/http.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { httpExchange } from './http.ts';
+import { makeTestOperation, makeTestForward, testExchange } from './test-utils.ts';
+import { isExchangeError } from '../errors.ts';
+import type { Operation } from '../exchange.ts';
+
+describe('httpExchange', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    globalThis.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('request execution', () => {
+    it('should execute query operation', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => ({ data: { user: { id: '1' } } }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(mockFetch).toHaveBeenCalled();
+      expect(results).toHaveLength(1);
+    });
+
+    it('should execute mutation operation', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { createUser: { id: '1' } } }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'mutation' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(mockFetch).toHaveBeenCalled();
+      expect(results).toHaveLength(1);
+    });
+
+    it('should not execute subscription operation', async () => {
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(forwardedOps).toHaveLength(1);
+    });
+
+    it('should not execute fragment operation', async () => {
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ kind: 'fragment' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetch behavior', () => {
+    it('should send POST request with correct body', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query', name: 'GetUser', variables: { id: 1 } });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://test.com/graphql',
+        expect.objectContaining({
+          method: 'POST',
+        }),
+      );
+    });
+
+    it('should include query source in body', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1].body);
+      expect(body).toHaveProperty('query');
+    });
+
+    it('should include variables in body', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query', variables: { id: 1 } });
+
+      await testExchange(exchange, forward, [operation]);
+
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1].body);
+      expect(body.variables).toEqual({ id: 1 });
+    });
+
+    it('should set Content-Type header to application/json', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[1].headers['Content-Type']).toBe('application/json');
+    });
+
+    it('should include custom headers', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const exchange = httpExchange({
+        url: 'http://test.com/graphql',
+        headers: { Authorization: 'Bearer token123' },
+      });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[1].headers.Authorization).toBe('Bearer token123');
+    });
+  });
+
+  describe('response handling', () => {
+    it('should parse successful response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { user: { id: '1', name: 'Alice' } } }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].data).toEqual({ user: { id: '1', name: 'Alice' } });
+    });
+
+    it('should extract data from response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: { test: true } }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].data).toEqual({ test: true });
+    });
+
+    it('should extract GraphQL errors from response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          errors: [{ message: 'User not found' }],
+        }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].errors).toBeDefined();
+      expect(results[0].errors).toHaveLength(1);
+      expect(results[0].errors![0].message).toBe('User not found');
+    });
+
+    it('should extract extensions from response', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          data: {},
+          extensions: { tracing: { duration: 123 } },
+        }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].extensions).toEqual({ tracing: { duration: 123 } });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle network errors', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].errors).toBeDefined();
+      expect(results[0].errors![0].message).toBe('Network error');
+    });
+
+    it('should handle HTTP error status codes', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].errors).toBeDefined();
+      expect(results[0].errors![0].message).toContain('500');
+    });
+
+    it('should handle JSON parse errors', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => {
+          throw new Error('Invalid JSON');
+        },
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].errors).toBeDefined();
+      expect(results[0].errors![0].message).toBe('Invalid JSON');
+    });
+
+    it('should create ExchangeError with correct properties', async () => {
+      mockFetch.mockRejectedValue(new Error('Test error'));
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(isExchangeError(results[0].errors![0], 'http')).toBe(true);
+    });
+  });
+
+  describe('teardown operations', () => {
+    it('should forward teardown operations', async () => {
+      const exchange = httpExchange({ url: 'http://test.com/graphql' });
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ variant: 'teardown' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+      expect(forwardedOps[0].variant).toBe('teardown');
+    });
+  });
+
+  describe('fetch options', () => {
+    it('should use provided URL', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const exchange = httpExchange({ url: 'http://custom.com/api' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(mockFetch).toHaveBeenCalledWith('http://custom.com/api', expect.anything());
+    });
+
+    it('should use provided mode', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql', mode: 'cors' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[1].mode).toBe('cors');
+    });
+
+    it('should use provided credentials', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const exchange = httpExchange({ url: 'http://test.com/graphql', credentials: 'include' });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      const callArgs = mockFetch.mock.calls[0];
+      expect(callArgs[1].credentials).toBe('include');
+    });
+  });
+});

--- a/packages/core/src/exchanges/retry.test.ts
+++ b/packages/core/src/exchanges/retry.test.ts
@@ -1,0 +1,628 @@
+import { describe, it, expect } from 'vitest';
+import { retryExchange } from './retry.ts';
+import { makeTestOperation, makeTestForward, testExchange } from './test-utils.ts';
+import { ExchangeError } from '../errors.ts';
+
+describe('retryExchange', () => {
+  describe('basic retry', () => {
+    it('should retry on retryable error', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 3, backoff: () => 0 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        if (callCount < 3) {
+          return {
+            operation: op,
+            errors: [
+              new ExchangeError('HTTP 500', {
+                exchangeName: 'http',
+                extensions: { statusCode: 500 },
+              }),
+            ],
+          };
+        }
+        return { operation: op, data: { success: true } };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(callCount).toBe(3);
+      expect(results[0].data).toEqual({ success: true });
+    });
+
+    it('should not retry on non-retryable error', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 3 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 404', {
+              exchangeName: 'http',
+              extensions: { statusCode: 404 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      const results = await promise;
+
+      expect(callCount).toBe(1);
+      expect(results[0].errors).toBeDefined();
+    });
+
+    it('should not retry successful operations', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 3 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return { operation: op, data: { success: true } };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(callCount).toBe(1);
+      expect(results[0].data).toEqual({ success: true });
+    });
+
+    it('should not retry mutations', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 3 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'mutation' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      const results = await promise;
+
+      expect(callCount).toBe(1);
+      expect(results[0].errors).toBeDefined();
+    });
+  });
+
+  describe('retry attempts', () => {
+    it('should respect maxAttempts option', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 2 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      const results = await promise;
+
+      expect(callCount).toBe(2);
+      expect(results[0].errors).toBeDefined();
+    });
+
+    it('should default to 3 attempts', async () => {
+      let callCount = 0;
+      const exchange = retryExchange();
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      const results = await promise;
+
+      expect(callCount).toBe(3);
+      expect(results[0].errors).toBeDefined();
+    });
+
+    it('should stop after max attempts reached', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 2 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(callCount).toBe(2);
+    });
+  });
+
+  describe('backoff', () => {
+    it('should use default exponential backoff', async () => {
+      let callCount = 0;
+      const delays: number[] = [];
+      const exchange = retryExchange({ maxAttempts: 3 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        if (callCount > 1) {
+          delays.push(Date.now());
+        }
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(callCount).toBe(3);
+    });
+
+    it('should use custom backoff function', async () => {
+      let callCount = 0;
+      const backoffCalls: number[] = [];
+      const exchange = retryExchange({
+        maxAttempts: 3,
+        backoff: (attempt) => {
+          backoffCalls.push(attempt);
+          return 100;
+        },
+      });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(backoffCalls).toHaveLength(2);
+      expect(backoffCalls).toEqual([0, 1]);
+    });
+
+    it('should delay retry by backoff duration', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({
+        maxAttempts: 2,
+        backoff: () => 0,
+      });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(callCount).toBe(2);
+    });
+
+    it('should cap backoff at 30 seconds', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({
+        maxAttempts: 3,
+      });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(callCount).toBe(3);
+    });
+  });
+
+  describe('shouldRetry function', () => {
+    it('should retry on HTTP 500 errors by default', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 2 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(callCount).toBe(2);
+    });
+
+    it('should retry on HTTP 502 errors by default', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 2 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 502', {
+              exchangeName: 'http',
+              extensions: { statusCode: 502 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(callCount).toBe(2);
+    });
+
+    it('should retry on HTTP 503 errors by default', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 2 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 503', {
+              exchangeName: 'http',
+              extensions: { statusCode: 503 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(callCount).toBe(2);
+    });
+
+    it('should not retry on HTTP 400 errors by default', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 3 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 400', {
+              exchangeName: 'http',
+              extensions: { statusCode: 400 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(callCount).toBe(1);
+    });
+
+    it('should not retry on HTTP 404 errors by default', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 3 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 404', {
+              exchangeName: 'http',
+              extensions: { statusCode: 404 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(callCount).toBe(1);
+    });
+
+    it('should use custom shouldRetry function', async () => {
+      let callCount = 0;
+      const shouldRetryCalls: unknown[] = [];
+      const exchange = retryExchange({
+        maxAttempts: 3,
+        shouldRetry: (error) => {
+          shouldRetryCalls.push(error);
+          return false;
+        },
+      });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(callCount).toBe(1);
+      expect(shouldRetryCalls).toHaveLength(1);
+    });
+  });
+
+  describe('retry metadata', () => {
+    it('should add retry metadata to operation', async () => {
+      let retryOp;
+      const exchange = retryExchange({ maxAttempts: 2 });
+      const forward = makeTestForward((op) => {
+        if (op.metadata.retry) {
+          retryOp = op;
+        }
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(retryOp).toBeDefined();
+      expect(retryOp.metadata.retry).toBeDefined();
+    });
+
+    it('should increment attempt counter', async () => {
+      const attempts: number[] = [];
+      const exchange = retryExchange({ maxAttempts: 3 });
+      const forward = makeTestForward((op) => {
+        if (op.metadata.retry) {
+          attempts.push(op.metadata.retry.attempt);
+        }
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(attempts).toEqual([1, 2]);
+    });
+
+    it('should include delay in metadata', async () => {
+      let retryOp;
+
+      const exchange = retryExchange({ maxAttempts: 2, backoff: () => 1000 });
+      const forward = makeTestForward((op) => {
+        if (op.metadata.retry) {
+          retryOp = op;
+        }
+
+        return {
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(retryOp.metadata.retry.delay).toBe(1000);
+    });
+
+    it('should set dedup.skip to true for retries', async () => {
+      let retryOp;
+      const exchange = retryExchange({ maxAttempts: 2 });
+      const forward = makeTestForward((op) => {
+        if (op.metadata.retry) {
+          retryOp = op;
+        }
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const promise = testExchange(exchange, forward, [operation]);
+      await promise;
+
+      expect(retryOp.metadata.dedup?.skip).toBe(true);
+    });
+  });
+
+  describe('teardown handling', () => {
+    it('should cancel retry on teardown', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 3, backoff: () => 0 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query', key: 'test-op' });
+      const teardown = makeTestOperation({ variant: 'teardown', key: 'test-op' });
+
+      const promise = testExchange(exchange, forward, [operation, teardown]);
+      await promise;
+
+      expect(callCount).toBe(1);
+    });
+
+    it('should not retry after teardown', async () => {
+      let callCount = 0;
+      const exchange = retryExchange({ maxAttempts: 3, backoff: () => 0 });
+      const forward = makeTestForward((op) => {
+        callCount++;
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+      const operation = makeTestOperation({ kind: 'query', key: 'test-op' });
+      const teardown = makeTestOperation({ variant: 'teardown', key: 'test-op' });
+
+      const promise = testExchange(exchange, forward, [operation, teardown]);
+      await promise;
+
+      expect(callCount).toBe(1);
+    });
+
+    it('should handle teardowns for multiple retry operations without race conditions', async () => {
+      let attempt1Count = 0;
+      let attempt2Count = 0;
+      let attempt3Count = 0;
+
+      const exchange = retryExchange({ maxAttempts: 3, backoff: () => 0 });
+      const forward = makeTestForward((op) => {
+        if (op.variant === 'teardown') {
+          return { operation: op };
+        }
+
+        if (op.key === 'op1') attempt1Count++;
+        if (op.key === 'op2') attempt2Count++;
+        if (op.key === 'op3') attempt3Count++;
+
+        return {
+          operation: op,
+          errors: [
+            new ExchangeError('HTTP 500', {
+              exchangeName: 'http',
+              extensions: { statusCode: 500 },
+            }),
+          ],
+        };
+      });
+
+      const operation1 = makeTestOperation({ kind: 'query', key: 'op1' });
+      const operation2 = makeTestOperation({ kind: 'query', key: 'op2' });
+      const operation3 = makeTestOperation({ kind: 'query', key: 'op3' });
+      const teardown1 = makeTestOperation({ variant: 'teardown', key: 'op1' });
+      const teardown2 = makeTestOperation({ variant: 'teardown', key: 'op2' });
+      const teardown3 = makeTestOperation({ variant: 'teardown', key: 'op3' });
+
+      await testExchange(exchange, forward, [
+        operation1,
+        operation2,
+        operation3,
+        teardown1,
+        teardown2,
+        teardown3,
+      ]);
+
+      expect(attempt1Count).toBe(1);
+      expect(attempt2Count).toBe(1);
+      expect(attempt3Count).toBe(1);
+    });
+  });
+});

--- a/packages/core/src/exchanges/subscription.test.ts
+++ b/packages/core/src/exchanges/subscription.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi } from 'vitest';
+import { subscriptionExchange } from './subscription.ts';
+import type { SubscriptionClient } from './subscription.ts';
+import { makeTestOperation, makeTestForward, testExchange } from './test-utils.ts';
+import { isExchangeError } from '../errors.ts';
+import type { Operation } from '../exchange.ts';
+
+type SubscriptionClientHandler = (
+  payload: unknown,
+  sink: {
+    next: (value: unknown) => void;
+    error: (error: Error) => void;
+    complete: () => void;
+  },
+) => () => void;
+
+const makeSubscriptionClient = (handler?: SubscriptionClientHandler): SubscriptionClient => {
+  return {
+    subscribe: vi.fn(
+      handler ??
+        ((_payload, sink: { complete: () => void }) => {
+          sink.complete();
+          return () => {};
+        }),
+    ),
+  };
+};
+
+describe('subscriptionExchange', () => {
+  describe('subscription operations', () => {
+    it('should handle subscription operation', async () => {
+      const mockClient = makeSubscriptionClient((_payload, sink) => {
+        setTimeout(() => sink.next({ data: { count: 1 } }), 0);
+        return () => {};
+      });
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(mockClient.subscribe).toHaveBeenCalled();
+    });
+
+    it('should forward non-subscription operations', async () => {
+      const mockClient = makeSubscriptionClient();
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op, data: { test: true } };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+      expect(mockClient.subscribe).not.toHaveBeenCalled();
+    });
+
+    it('should forward teardown operations', async () => {
+      const mockClient = makeSubscriptionClient();
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ variant: 'teardown' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+      expect(forwardedOps[0]!.variant).toBe('teardown');
+    });
+  });
+
+  describe('client integration', () => {
+    it('should call client.subscribe with query', async () => {
+      const mockClient = makeSubscriptionClient();
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription', name: 'OnMessageAdded' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(mockClient.subscribe).toHaveBeenCalledWith(
+        expect.objectContaining({ query: expect.any(String) }),
+        expect.any(Object),
+      );
+    });
+
+    it('should call client.subscribe with variables', async () => {
+      const mockClient = makeSubscriptionClient();
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({
+        kind: 'subscription',
+        variables: { roomId: '123' },
+      });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(mockClient.subscribe).toHaveBeenCalledWith(
+        expect.objectContaining({ variables: { roomId: '123' } }),
+        expect.any(Object),
+      );
+    });
+
+    it('should pass observer to client', async () => {
+      const mockClient = makeSubscriptionClient();
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(mockClient.subscribe).toHaveBeenCalledWith(expect.any(Object), {
+        next: expect.any(Function),
+        error: expect.any(Function),
+        complete: expect.any(Function),
+      });
+    });
+  });
+
+  describe('data handling', () => {
+    it('should emit data from subscription', async () => {
+      const mockClient = makeSubscriptionClient((_payload, sink) => {
+        setTimeout(() => {
+          sink.next({ data: { message: 'Hello' } });
+          sink.complete();
+        }, 0);
+        return () => {};
+      });
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0]!.data).toEqual({ message: 'Hello' });
+    });
+
+    it('should convert GraphQL errors to error objects', async () => {
+      const mockClient = makeSubscriptionClient((_payload, sink) => {
+        setTimeout(() => {
+          sink.next({
+            errors: [{ message: 'Subscription error' }],
+          });
+          sink.complete();
+        }, 0);
+        return () => {};
+      });
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0]!.errors).toBeDefined();
+      expect(results[0]!.errors![0]!.message).toBe('Subscription error');
+    });
+
+    it('should include extensions from response', async () => {
+      const mockClient = makeSubscriptionClient((_payload, sink) => {
+        setTimeout(() => {
+          sink.next({
+            data: { test: true },
+            extensions: { custom: 'data' },
+          });
+          sink.complete();
+        }, 0);
+        return () => {};
+      });
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0]!.extensions).toEqual({ custom: 'data' });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle client errors', async () => {
+      const mockClient = makeSubscriptionClient((_payload, sink) => {
+        setTimeout(() => sink.error(new Error('Connection failed')), 0);
+        return () => {};
+      });
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0]!.errors).toBeDefined();
+      expect(results[0]!.errors![0]!.message).toBe('Connection failed');
+    });
+
+    it('should create ExchangeError on error', async () => {
+      const mockClient = makeSubscriptionClient((_payload, sink) => {
+        setTimeout(() => sink.error(new Error('Test error')), 0);
+        return () => {};
+      });
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(isExchangeError(results[0]!.errors![0]!, 'subscription')).toBe(true);
+    });
+
+    it('should complete stream on error', async () => {
+      let completed = false;
+      const mockClient = makeSubscriptionClient((_payload, sink) => {
+        setTimeout(() => {
+          sink.error(new Error('Test error'));
+        }, 0);
+        return () => {
+          completed = true;
+        };
+      });
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(completed).toBe(true);
+    });
+  });
+
+  describe('subscription lifecycle', () => {
+    it('should call unsubscribe on teardown', async () => {
+      const unsubscribeFn = vi.fn();
+      const mockClient = makeSubscriptionClient(() => {
+        return unsubscribeFn;
+      });
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription', key: 'sub-1' });
+      const teardown = makeTestOperation({ variant: 'teardown', key: 'sub-1' });
+
+      await testExchange(exchange, forward, [operation, teardown]);
+
+      expect(unsubscribeFn).toHaveBeenCalled();
+    });
+
+    it('should complete stream on teardown', async () => {
+      const mockClient = makeSubscriptionClient();
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription', key: 'sub-1' });
+      const teardown = makeTestOperation({ variant: 'teardown', key: 'sub-1' });
+
+      const results = await testExchange(exchange, forward, [operation, teardown]);
+
+      expect(results).toBeDefined();
+    });
+
+    it('should handle multiple emissions', async () => {
+      const mockClient = makeSubscriptionClient((_payload, sink) => {
+        setTimeout(() => sink.next({ data: { count: 1 } }), 0);
+        setTimeout(() => sink.next({ data: { count: 2 } }), 0);
+        setTimeout(() => sink.next({ data: { count: 3 } }), 0);
+        setTimeout(() => sink.complete(), 0);
+        return () => {};
+      });
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should handle completion from client', async () => {
+      const mockClient = makeSubscriptionClient((_payload, sink) => {
+        setTimeout(() => {
+          sink.next({ data: { final: true } });
+          sink.complete();
+        }, 0);
+        return () => {};
+      });
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0]!.data).toEqual({ final: true });
+    });
+  });
+
+  describe('operation filtering', () => {
+    it('should not forward subscription operations', async () => {
+      const mockClient = makeSubscriptionClient();
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(0);
+    });
+
+    it('should forward queries', async () => {
+      const mockClient = makeSubscriptionClient();
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+      expect(forwardedOps[0]!.variant).toBe('request');
+    });
+
+    it('should forward mutations', async () => {
+      const mockClient = makeSubscriptionClient();
+
+      const exchange = subscriptionExchange({ client: mockClient });
+      const forwardedOps: Operation[] = [];
+      const forward = makeTestForward((op) => {
+        forwardedOps.push(op);
+        return { operation: op };
+      });
+      const operation = makeTestOperation({ kind: 'mutation' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardedOps).toHaveLength(1);
+      expect(forwardedOps[0]!.variant).toBe('request');
+    });
+  });
+});

--- a/packages/core/src/exchanges/terminal.test.ts
+++ b/packages/core/src/exchanges/terminal.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { terminalExchange } from './terminal.ts';
+import { makeTestOperation, makeTestForward, testExchange } from './test-utils.ts';
+import { isExchangeError } from '../errors.ts';
+
+describe('terminalExchange', () => {
+  describe('error handling', () => {
+    it('should return error for request operation', async () => {
+      const exchange = terminalExchange();
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].errors).toBeDefined();
+      expect(results[0].errors).toHaveLength(1);
+    });
+
+    it('should return error for query operation', async () => {
+      const exchange = terminalExchange();
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].errors).toBeDefined();
+    });
+
+    it('should return error for mutation operation', async () => {
+      const exchange = terminalExchange();
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'mutation' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].errors).toBeDefined();
+    });
+
+    it('should return error for subscription operation', async () => {
+      const exchange = terminalExchange();
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'subscription' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].errors).toBeDefined();
+    });
+  });
+
+  describe('error details', () => {
+    it('should include correct error message', async () => {
+      const exchange = terminalExchange();
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      const error = results[0].errors![0];
+      expect(error.message).toBe(
+        'No terminal exchange found in exchange chain. Did you forget to add httpExchange to your exchanges array?',
+      );
+    });
+
+    it('should set exchangeName to terminal', async () => {
+      const exchange = terminalExchange();
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      const error = results[0].errors![0];
+      expect(isExchangeError(error, 'terminal')).toBe(true);
+    });
+
+    it('should preserve operation in result', async () => {
+      const exchange = terminalExchange();
+      const forward = makeTestForward();
+      const operation = makeTestOperation({ kind: 'query', name: 'TestQuery' });
+
+      const results = await testExchange(exchange, forward, [operation]);
+
+      expect(results[0].operation).toEqual(operation);
+    });
+  });
+
+  describe('multiple operations', () => {
+    it('should return error for each request operation', async () => {
+      const exchange = terminalExchange();
+      const forward = makeTestForward();
+      const op1 = makeTestOperation({ kind: 'query' });
+      const op2 = makeTestOperation({ kind: 'mutation' });
+      const op3 = makeTestOperation({ kind: 'subscription' });
+
+      const results = await testExchange(exchange, forward, [op1, op2, op3]);
+
+      expect(results).toHaveLength(3);
+      expect(results[0].errors).toBeDefined();
+      expect(results[1].errors).toBeDefined();
+      expect(results[2].errors).toBeDefined();
+    });
+  });
+
+  describe('forward function', () => {
+    it('should not call forward function', async () => {
+      const exchange = terminalExchange();
+      let forwardCalled = false;
+      const forward = makeTestForward(() => {
+        forwardCalled = true;
+        return {};
+      });
+      const operation = makeTestOperation({ kind: 'query' });
+
+      await testExchange(exchange, forward, [operation]);
+
+      expect(forwardCalled).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/exchanges/test-utils.ts
+++ b/packages/core/src/exchanges/test-utils.ts
@@ -1,0 +1,102 @@
+import type { Operation, OperationResult, ExchangeIO, Exchange, RequestOperation } from '../exchange.ts';
+import type { ArtifactKind, Artifact, Selection } from '@mearie/shared';
+import { pipe } from '../stream/pipe.ts';
+import { map } from '../stream/operators/map.ts';
+import { vi } from 'vitest';
+import { fromArray } from '../stream/sources/from-array.ts';
+import { subscribe } from '../stream/sinks/subscribe.ts';
+
+let operationCounter = 0;
+
+export type TestOperationOptions = {
+  variant?: 'request' | 'teardown';
+  kind?: ArtifactKind;
+  name?: string;
+  variables?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  key?: string;
+  selections?: readonly Selection[];
+};
+
+export const makeTestOperation = (options: TestOperationOptions = {}): Operation => {
+  const {
+    variant = 'request',
+    kind = 'query',
+    name = `TestOperation${operationCounter}`,
+    variables = {},
+    metadata = {},
+    key = `op-${++operationCounter}`,
+    selections = [],
+  } = options;
+
+  if (variant === 'teardown') {
+    return {
+      variant: 'teardown',
+      key,
+      metadata,
+    };
+  }
+
+  const artifact: Artifact = {
+    kind,
+    name,
+    source: '',
+    selections,
+  };
+
+  return {
+    variant: 'request',
+    key,
+    metadata,
+    artifact,
+    variables,
+  } as RequestOperation;
+};
+
+export type ForwardHandler = (operation: Operation) => Partial<OperationResult>;
+
+export const makeTestForward = (handler?: ForwardHandler): ExchangeIO => {
+  return (ops$) =>
+    pipe(
+      ops$,
+      map((op): OperationResult => {
+        if (handler) {
+          const result = handler(op);
+          return {
+            operation: op,
+            data: result.data,
+            errors: result.errors,
+            extensions: result.extensions,
+            stale: result.stale,
+          };
+        } else {
+          return { operation: op };
+        }
+      }),
+    );
+};
+
+export const testExchange = async (
+  exchange: Exchange,
+  forward: ExchangeIO,
+  operations: Operation[],
+): Promise<OperationResult[]> => {
+  const results: OperationResult[] = [];
+  vi.useFakeTimers();
+
+  const unsubscribe = pipe(
+    fromArray(operations),
+    exchange(forward),
+    subscribe({
+      next: (result) => {
+        results.push(result);
+      },
+    }),
+  );
+
+  await vi.runAllTimersAsync();
+  vi.useRealTimers();
+  unsubscribe();
+
+  return results;
+};


### PR DESCRIPTION
Adds complete test coverage for the exchange system with 8 new test files covering all exchange implementations.

- Tests for cacheExchange including all fetch policies and cache operations
- Tests for composeExchange covering exchange composition patterns
- Tests for dedupExchange validating duplicate request handling
- Tests for fragmentExchange with fragment spreading scenarios
- Tests for httpExchange covering HTTP operations and error cases
- Tests for retryExchange with various backoff strategies
- Tests for subscriptionExchange including WebSocket operations
- Tests for terminalExchange validating operation termination
- Shared test utilities for consistent testing patterns