### PR TITLE
perf(core): optimize field key generation for empty arguments

### DIFF
--- a/.changeset/quiet-sheep-jump.md
+++ b/.changeset/quiet-sheep-jump.md
@@ -1,0 +1,5 @@
+---
+'@mearie/core': patch
+---
+
+Optimize field key generation by checking for empty args before stringifying

--- a/packages/core/src/cache/utils.ts
+++ b/packages/core/src/cache/utils.ts
@@ -39,7 +39,11 @@ export const resolveArguments = (
  * @returns Field cache key string in "fieldName@argsString" format.
  */
 export const makeFieldKey = (selection: FieldSelection, variables: Record<string, unknown>): FieldKey => {
-  const args = selection.args ? stringify(resolveArguments(selection.args, variables)) : '{}';
+  const args =
+    selection.args && Object.keys(selection.args).length > 0
+      ? stringify(resolveArguments(selection.args, variables))
+      : '{}';
+
   return `${selection.name}@${args}`;
 };
 


### PR DESCRIPTION
Optimizes the field key generation in the cache system by checking if the args object has keys before stringifying.

This change improves performance by avoiding unnecessary stringification when the arguments object is empty, defaulting to '{}' directly.

The optimization specifically checks `Object.keys(selection.args).length > 0` before calling stringify.