### PR TITLE
test(core/stream): add comprehensive tests for operators and sources

### DIFF
--- a/packages/core/src/stream/operators/delay.test.ts
+++ b/packages/core/src/stream/operators/delay.test.ts
@@ -1,0 +1,548 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { delay } from './delay.ts';
+import { fromArray } from '../sources/from-array.ts';
+import { fromValue } from '../sources/from-value.ts';
+import { pipe } from '../pipe.ts';
+import type { Talkback } from '../types.ts';
+
+describe('delay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('basic functionality', () => {
+    it('should delay each value by specified time', () => {
+      const source = fromArray([1, 2, 3]);
+      const emitted: number[] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      expect(emitted).toEqual([]);
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([1, 2, 3]);
+    });
+
+    it('should delay single value', () => {
+      const source = fromValue(42);
+      const emitted: number[] = [];
+
+      pipe(
+        source,
+        delay(50),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      expect(emitted).toEqual([]);
+
+      vi.advanceTimersByTime(50);
+      expect(emitted).toEqual([42]);
+    });
+
+    it('should delay completion signal', () => {
+      const source = fromArray([1, 2, 3]);
+      let completed = false;
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: () => {},
+        complete: () => {
+          completed = true;
+        },
+      });
+
+      expect(completed).toBe(false);
+
+      vi.advanceTimersByTime(100);
+      expect(completed).toBe(true);
+    });
+
+    it('should handle empty source', () => {
+      const source = fromArray<number>([]);
+      let completed = false;
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: () => {},
+        complete: () => {
+          completed = true;
+        },
+      });
+
+      expect(completed).toBe(false);
+
+      vi.advanceTimersByTime(100);
+      expect(completed).toBe(true);
+    });
+  });
+
+  describe('delay timing', () => {
+    it('should delay by exact specified milliseconds', () => {
+      const source = fromArray([1]);
+      const emitted: number[] = [];
+
+      pipe(
+        source,
+        delay(250),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(249);
+      expect(emitted).toEqual([]);
+
+      vi.advanceTimersByTime(1);
+      expect(emitted).toEqual([1]);
+    });
+
+    it('should handle zero delay', () => {
+      const source = fromArray([1, 2, 3]);
+      const emitted: number[] = [];
+
+      pipe(
+        source,
+        delay(0),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      expect(emitted).toEqual([]);
+
+      vi.advanceTimersByTime(0);
+      expect(emitted).toEqual([1, 2, 3]);
+    });
+
+    it('should delay each value independently', () => {
+      const source = fromArray([1, 2, 3]);
+      const emitted: number[] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([1, 2, 3]);
+    });
+  });
+
+  describe('cancellation', () => {
+    it('should clear pending timeouts on cancel', () => {
+      const source = fromArray([1, 2, 3]);
+      const emitted: number[] = [];
+      let talkback: Talkback;
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      talkback.cancel();
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([]);
+    });
+
+    it('should not emit values after cancellation', () => {
+      const source = fromArray([1, 2, 3]);
+      const emitted: number[] = [];
+      let talkback: Talkback;
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(50);
+      talkback.cancel();
+      vi.advanceTimersByTime(50);
+
+      expect(emitted).toEqual([]);
+    });
+
+    it('should not emit completion after cancellation', () => {
+      const source = fromArray([1, 2, 3]);
+      let completed = false;
+      let talkback: Talkback;
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: () => {},
+        complete: () => {
+          completed = true;
+        },
+      });
+
+      talkback.cancel();
+      vi.advanceTimersByTime(100);
+
+      expect(completed).toBe(false);
+    });
+
+    it('should cancel upstream source', () => {
+      const source = fromArray([1, 2, 3]);
+      let talkback: Talkback;
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      expect(() => talkback.cancel()).not.toThrow();
+    });
+  });
+
+  describe('multiple values', () => {
+    it('should delay multiple values', () => {
+      const source = fromArray([1, 2, 3, 4, 5]);
+      const emitted: number[] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('should preserve value order', () => {
+      const source = fromArray([5, 4, 3, 2, 1]);
+      const emitted: number[] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([5, 4, 3, 2, 1]);
+    });
+  });
+
+  describe('value types', () => {
+    it('should delay strings', () => {
+      const source = fromArray(['a', 'b', 'c']);
+      const emitted: string[] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should delay objects', () => {
+      const source = fromArray([{ id: 1 }, { id: 2 }]);
+      const emitted: { id: number }[] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it('should delay arrays', () => {
+      const source = fromArray([
+        [1, 2],
+        [3, 4],
+      ]);
+      const emitted: number[][] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([
+        [1, 2],
+        [3, 4],
+      ]);
+    });
+  });
+
+  describe('falsy values', () => {
+    it('should delay null values', () => {
+      const source = fromArray<number | null>([1, null, 3]);
+      const emitted: (number | null)[] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([1, null, 3]);
+    });
+
+    it('should delay undefined values', () => {
+      const source = fromArray<number | undefined>([1, undefined, 3]);
+      const emitted: (number | undefined)[] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([1, undefined, 3]);
+    });
+
+    it('should delay zero', () => {
+      const source = fromArray([0, 1, 0]);
+      const emitted: number[] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([0, 1, 0]);
+    });
+
+    it('should delay false', () => {
+      const source = fromArray([true, false, true]);
+      const emitted: boolean[] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([true, false, true]);
+    });
+
+    it('should delay empty string', () => {
+      const source = fromArray(['a', '', 'c']);
+      const emitted: string[] = [];
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual(['a', '', 'c']);
+    });
+  });
+
+  describe('talkback', () => {
+    it('should provide talkback', () => {
+      const source = fromArray([1, 2, 3]);
+      let receivedTalkback: Talkback | null = null;
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: (tb) => {
+          receivedTalkback = tb;
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      expect(receivedTalkback).not.toBeNull();
+      expect(receivedTalkback).toHaveProperty('pull');
+      expect(receivedTalkback).toHaveProperty('cancel');
+    });
+
+    it('should forward pull to upstream', () => {
+      const source = fromArray([1, 2, 3]);
+      let talkback: Talkback;
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      expect(() => talkback.pull()).not.toThrow();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle cancellation before first value', () => {
+      const source = fromArray([1, 2, 3]);
+      const emitted: number[] = [];
+      let talkback: Talkback;
+
+      pipe(
+        source,
+        delay(100),
+      )({
+        start: (tb) => {
+          talkback = tb;
+          tb.cancel();
+        },
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(100);
+      expect(emitted).toEqual([]);
+    });
+
+    it('should handle very long delays', () => {
+      const source = fromValue(1);
+      const emitted: number[] = [];
+
+      pipe(
+        source,
+        delay(10000),
+      )({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      vi.advanceTimersByTime(9999);
+      expect(emitted).toEqual([]);
+
+      vi.advanceTimersByTime(1);
+      expect(emitted).toEqual([1]);
+    });
+  });
+});

--- a/packages/core/src/stream/sources/from-promise.test.ts
+++ b/packages/core/src/stream/sources/from-promise.test.ts
@@ -1,0 +1,473 @@
+import { describe, it, expect } from 'vitest';
+import { fromPromise } from './from-promise.ts';
+import { collectAll } from '../sinks/collect-all.ts';
+import { pipe } from '../pipe.ts';
+import { map } from '../operators/map.ts';
+import type { Talkback } from '../types.ts';
+
+describe('fromPromise', () => {
+  describe('basic functionality', () => {
+    it('should emit resolved promise value', async () => {
+      const promise = Promise.resolve(42);
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([42]);
+    });
+
+    it('should emit string value', async () => {
+      const promise = Promise.resolve('hello');
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual(['hello']);
+    });
+
+    it('should emit object value', async () => {
+      const promise = Promise.resolve({ id: 1, name: 'test' });
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([{ id: 1, name: 'test' }]);
+    });
+
+    it('should emit array value', async () => {
+      const promise = Promise.resolve([1, 2, 3]);
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([[1, 2, 3]]);
+    });
+
+    it('should complete after emitting value', async () => {
+      const promise = Promise.resolve(1);
+      const source = fromPromise(promise);
+      let completed = false;
+
+      await new Promise<void>((resolve) => {
+        source({
+          start: () => {},
+          next: () => {},
+          complete: () => {
+            completed = true;
+            resolve();
+          },
+        });
+      });
+
+      expect(completed).toBe(true);
+    });
+  });
+
+  describe('promise rejection', () => {
+    it('should complete without emitting on rejection', async () => {
+      const promise = Promise.reject(new Error('test error'));
+      const source = fromPromise(promise);
+      const emitted: unknown[] = [];
+      let completed = false;
+
+      await new Promise<void>((resolve) => {
+        source({
+          start: () => {},
+          next: (value) => {
+            emitted.push(value);
+          },
+          complete: () => {
+            completed = true;
+            resolve();
+          },
+        });
+      });
+
+      expect(emitted).toEqual([]);
+      expect(completed).toBe(true);
+    });
+
+    it('should complete on promise rejection with string', async () => {
+      const promise = Promise.reject('error string');
+      const source = fromPromise(promise);
+      let completed = false;
+
+      await new Promise<void>((resolve) => {
+        source({
+          start: () => {},
+          next: () => {},
+          complete: () => {
+            completed = true;
+            resolve();
+          },
+        });
+      });
+
+      expect(completed).toBe(true);
+    });
+
+    it('should complete on promise rejection with null', async () => {
+      const promise = Promise.reject(null);
+      const source = fromPromise(promise);
+      let completed = false;
+
+      await new Promise<void>((resolve) => {
+        source({
+          start: () => {},
+          next: () => {},
+          complete: () => {
+            completed = true;
+            resolve();
+          },
+        });
+      });
+
+      expect(completed).toBe(true);
+    });
+  });
+
+  describe('cancellation', () => {
+    it('should not emit if cancelled before promise resolves', async () => {
+      let resolvePromise: (value: number) => void;
+      const promise = new Promise<number>((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      const source = fromPromise(promise);
+      const emitted: number[] = [];
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+          tb.cancel();
+        },
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      resolvePromise!(42);
+      await promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(emitted).toEqual([]);
+    });
+
+    it('should not emit if cancelled after start', async () => {
+      let resolvePromise: (value: number) => void;
+      const promise = new Promise<number>((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      const source = fromPromise(promise);
+      const emitted: number[] = [];
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      talkback.cancel();
+      resolvePromise!(42);
+      await promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(emitted).toEqual([]);
+    });
+
+    it('should not complete if cancelled', async () => {
+      let resolvePromise: (value: number) => void;
+      const promise = new Promise<number>((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      const source = fromPromise(promise);
+      let completed = false;
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+          tb.cancel();
+        },
+        next: () => {},
+        complete: () => {
+          completed = true;
+        },
+      });
+
+      resolvePromise!(42);
+      await promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(completed).toBe(false);
+    });
+  });
+
+  describe('already resolved promise', () => {
+    it('should handle already resolved promise', async () => {
+      const promise = Promise.resolve(100);
+      await promise;
+
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([100]);
+    });
+
+    it('should handle already rejected promise', async () => {
+      const promise = Promise.reject(new Error('test'));
+
+      try {
+        await promise;
+      } catch {}
+
+      const source = fromPromise(promise);
+      const emitted: unknown[] = [];
+
+      await new Promise<void>((resolve) => {
+        source({
+          start: () => {},
+          next: (value) => {
+            emitted.push(value);
+          },
+          complete: () => {
+            resolve();
+          },
+        });
+      });
+
+      expect(emitted).toEqual([]);
+    });
+  });
+
+  describe('falsy values', () => {
+    it('should emit null', async () => {
+      const promise = Promise.resolve(null);
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([null]);
+    });
+
+    it('should emit undefined', async () => {
+      const promise = Promise.resolve(undefined);
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([undefined]);
+    });
+
+    it('should emit zero', async () => {
+      const promise = Promise.resolve(0);
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([0]);
+    });
+
+    it('should emit false', async () => {
+      const promise = Promise.resolve(false);
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([false]);
+    });
+
+    it('should emit empty string', async () => {
+      const promise = Promise.resolve('');
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual(['']);
+    });
+  });
+
+  describe('with operators', () => {
+    it('should work with map', async () => {
+      const promise = Promise.resolve(10);
+      const source = fromPromise(promise);
+
+      const result = await pipe(
+        source,
+        map((x) => x * 2),
+        collectAll,
+      );
+
+      expect(result).toEqual([20]);
+    });
+
+    it('should work with multiple operators', async () => {
+      const promise = Promise.resolve(5);
+      const source = fromPromise(promise);
+
+      const result = await pipe(
+        source,
+        map((x) => x * 2),
+        map((x) => x + 10),
+        collectAll,
+      );
+
+      expect(result).toEqual([20]);
+    });
+  });
+
+  describe('talkback', () => {
+    it('should provide talkback', async () => {
+      const promise = Promise.resolve(42);
+      const source = fromPromise(promise);
+      let receivedTalkback: Talkback | null = null;
+
+      await new Promise<void>((resolve) => {
+        source({
+          start: (tb) => {
+            receivedTalkback = tb;
+          },
+          next: () => {},
+          complete: () => {
+            resolve();
+          },
+        });
+      });
+
+      expect(receivedTalkback).not.toBeNull();
+      expect(receivedTalkback).toHaveProperty('pull');
+      expect(receivedTalkback).toHaveProperty('cancel');
+    });
+
+    it('should have pull method that does nothing', async () => {
+      const promise = Promise.resolve(42);
+      const source = fromPromise(promise);
+
+      await new Promise<void>((resolve) => {
+        source({
+          start: (tb) => {
+            expect(() => tb.pull()).not.toThrow();
+          },
+          next: () => {},
+          complete: () => {
+            resolve();
+          },
+        });
+      });
+    });
+  });
+
+  describe('async behavior', () => {
+    it('should emit value asynchronously', async () => {
+      const promise = Promise.resolve(1);
+      const source = fromPromise(promise);
+      const emitted: number[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      expect(emitted).toEqual([]);
+
+      await promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(emitted).toEqual([1]);
+    });
+
+    it('should complete asynchronously', async () => {
+      const promise = Promise.resolve(1);
+      const source = fromPromise(promise);
+      let completed = false;
+
+      source({
+        start: () => {},
+        next: () => {},
+        complete: () => {
+          completed = true;
+        },
+      });
+
+      expect(completed).toBe(false);
+
+      await promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(completed).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle promise with complex object', async () => {
+      const complexObject = {
+        id: 1,
+        nested: {
+          value: 'test',
+          array: [1, 2, 3],
+          deep: {
+            property: true,
+          },
+        },
+      };
+      const promise = Promise.resolve(complexObject);
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([complexObject]);
+    });
+
+    it('should handle promise with NaN', async () => {
+      const promise = Promise.resolve(Number.NaN);
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result[0]).toBeNaN();
+    });
+
+    it('should handle promise with Infinity', async () => {
+      const promise = Promise.resolve(Infinity);
+      const source = fromPromise(promise);
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([Infinity]);
+    });
+
+    it('should handle cancellation immediately after start', async () => {
+      const promise = Promise.resolve(42);
+      const source = fromPromise(promise);
+      const emitted: number[] = [];
+
+      source({
+        start: (tb) => {
+          tb.cancel();
+        },
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      await promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(emitted).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/stream/sources/from-subscription.test.ts
+++ b/packages/core/src/stream/sources/from-subscription.test.ts
@@ -1,0 +1,629 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fromSubscription } from './from-subscription.ts';
+import { collectAll } from '../sinks/collect-all.ts';
+import { pipe } from '../pipe.ts';
+import { map } from '../operators/map.ts';
+import type { Talkback } from '../types.ts';
+
+describe('fromSubscription', () => {
+  describe('basic functionality', () => {
+    it('should emit initial value immediately', () => {
+      let state = 1;
+      const pull = () => state;
+      const poke = () => () => {};
+
+      const source = fromSubscription(pull, poke);
+      const emitted: number[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      expect(emitted).toEqual([1]);
+    });
+
+    it('should emit new values when signal is called', () => {
+      let state = 1;
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: number[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      expect(emitted).toEqual([1]);
+
+      state = 2;
+      signal!();
+      expect(emitted).toEqual([1, 2]);
+
+      state = 3;
+      signal!();
+      expect(emitted).toEqual([1, 2, 3]);
+    });
+
+    it('should call unsubscribe on cancel', () => {
+      let state = 1;
+      const pull = () => state;
+      const unsubscribe = vi.fn();
+      const poke = () => unsubscribe;
+
+      const source = fromSubscription(pull, poke);
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      expect(unsubscribe).not.toHaveBeenCalled();
+
+      talkback.cancel();
+
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pull latest value on signal', () => {
+      let state = 10;
+      const pull = vi.fn(() => state);
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: number[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      expect(pull).toHaveBeenCalledTimes(1);
+
+      state = 20;
+      signal!();
+
+      expect(pull).toHaveBeenCalledTimes(2);
+      expect(emitted).toEqual([10, 20]);
+    });
+  });
+
+  describe('cancellation', () => {
+    it('should not emit if cancelled before subscription', () => {
+      let state = 1;
+      const pull = () => state;
+      const poke = () => () => {};
+
+      const source = fromSubscription(pull, poke);
+      const emitted: number[] = [];
+
+      source({
+        start: (tb) => {
+          tb.cancel();
+        },
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      expect(emitted).toEqual([]);
+    });
+
+    it('should not emit after cancellation', () => {
+      let state = 1;
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: number[] = [];
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      expect(emitted).toEqual([1]);
+
+      talkback.cancel();
+
+      state = 2;
+      signal!();
+
+      expect(emitted).toEqual([1]);
+    });
+
+    it('should not setup poke if cancelled after initial value', () => {
+      let state = 1;
+      const pull = () => state;
+      const poke = vi.fn(() => () => {});
+
+      const source = fromSubscription(pull, poke);
+      let cancelled = false;
+
+      source({
+        start: (tb) => {
+          tb.cancel();
+          cancelled = true;
+        },
+        next: () => {
+          if (cancelled) {
+            throw new Error('Should not emit after cancellation');
+          }
+        },
+        complete: () => {},
+      });
+
+      expect(poke).not.toHaveBeenCalled();
+    });
+
+    it('should call unsubscribe only once', () => {
+      let state = 1;
+      const pull = () => state;
+      const unsubscribe = vi.fn();
+      const poke = () => unsubscribe;
+
+      const source = fromSubscription(pull, poke);
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      talkback.cancel();
+      talkback.cancel();
+      talkback.cancel();
+
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('value types', () => {
+    it('should handle string values', () => {
+      let state = 'initial';
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: string[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      state = 'updated';
+      signal!();
+
+      expect(emitted).toEqual(['initial', 'updated']);
+    });
+
+    it('should handle object values', () => {
+      let state = { count: 1 };
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: { count: number }[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      state = { count: 2 };
+      signal!();
+
+      expect(emitted).toEqual([{ count: 1 }, { count: 2 }]);
+    });
+
+    it('should handle array values', () => {
+      let state = [1, 2, 3];
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: number[][] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      state = [4, 5, 6];
+      signal!();
+
+      expect(emitted).toEqual([
+        [1, 2, 3],
+        [4, 5, 6],
+      ]);
+    });
+  });
+
+  describe('falsy values', () => {
+    it('should emit null values', () => {
+      let state: number | null = null;
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: (number | null)[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      state = 1;
+      signal!();
+
+      state = null;
+      signal!();
+
+      expect(emitted).toEqual([null, 1, null]);
+    });
+
+    it('should emit undefined values', () => {
+      let state: number | undefined = undefined;
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: (number | undefined)[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      state = 1;
+      signal!();
+
+      expect(emitted).toEqual([undefined, 1]);
+    });
+
+    it('should emit zero', () => {
+      let state = 0;
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: number[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      state = 1;
+      signal!();
+
+      state = 0;
+      signal!();
+
+      expect(emitted).toEqual([0, 1, 0]);
+    });
+
+    it('should emit false', () => {
+      let state = false;
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: boolean[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      state = true;
+      signal!();
+
+      state = false;
+      signal!();
+
+      expect(emitted).toEqual([false, true, false]);
+    });
+
+    it('should emit empty string', () => {
+      let state = '';
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: string[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      state = 'a';
+      signal!();
+
+      state = '';
+      signal!();
+
+      expect(emitted).toEqual(['', 'a', '']);
+    });
+  });
+
+  describe('with operators', () => {
+    it('should work with map', async () => {
+      let state = 1;
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+
+      const promise = new Promise<number[]>((resolve) => {
+        const emitted: number[] = [];
+        pipe(
+          source,
+          map((x) => x * 2),
+        )({
+          start: () => {},
+          next: (value) => {
+            emitted.push(value);
+            if (emitted.length === 3) {
+              resolve(emitted);
+            }
+          },
+          complete: () => {},
+        });
+
+        state = 2;
+        signal!();
+
+        state = 3;
+        signal!();
+      });
+
+      const result = await promise;
+      expect(result).toEqual([2, 4, 6]);
+    });
+  });
+
+  describe('talkback', () => {
+    it('should provide talkback', () => {
+      let state = 1;
+      const pull = () => state;
+      const poke = () => () => {};
+
+      const source = fromSubscription(pull, poke);
+      let receivedTalkback: Talkback | null = null;
+
+      source({
+        start: (tb) => {
+          receivedTalkback = tb;
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      expect(receivedTalkback).not.toBeNull();
+      expect(receivedTalkback).toHaveProperty('pull');
+      expect(receivedTalkback).toHaveProperty('cancel');
+    });
+
+    it('should have pull method that does nothing', () => {
+      let state = 1;
+      const pull = () => state;
+      const poke = () => () => {};
+
+      const source = fromSubscription(pull, poke);
+
+      source({
+        start: (tb) => {
+          expect(() => tb.pull()).not.toThrow();
+        },
+        next: () => {},
+        complete: () => {},
+      });
+    });
+  });
+
+  describe('multiple signals', () => {
+    it('should handle multiple rapid signals', () => {
+      let state = 0;
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: number[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      for (let i = 1; i <= 10; i++) {
+        state = i;
+        signal!();
+      }
+
+      expect(emitted).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    });
+
+    it('should handle signal without state change', () => {
+      let state = 1;
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: number[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      signal!();
+      signal!();
+
+      expect(emitted).toEqual([1, 1, 1]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle unsubscribe returning undefined', () => {
+      let state = 1;
+      const pull = () => state;
+      const poke = () => undefined as unknown as () => void;
+
+      const source = fromSubscription(pull, poke);
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      expect(() => talkback.cancel()).not.toThrow();
+    });
+
+    it('should handle complex state objects', () => {
+      let state = { users: [{ id: 1, name: 'Alice' }], count: 1 };
+      const pull = () => state;
+      let signal: (() => void) | null = null;
+      const poke = (s: () => void) => {
+        signal = s;
+        return () => {};
+      };
+
+      const source = fromSubscription(pull, poke);
+      const emitted: typeof state[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      state = { users: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }], count: 2 };
+      signal!();
+
+      expect(emitted).toEqual([
+        { users: [{ id: 1, name: 'Alice' }], count: 1 },
+        { users: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }], count: 2 },
+      ]);
+    });
+  });
+});

--- a/packages/core/src/stream/sources/make.test.ts
+++ b/packages/core/src/stream/sources/make.test.ts
@@ -1,0 +1,625 @@
+import { describe, it, expect, vi } from 'vitest';
+import { make } from './make.ts';
+import { collectAll } from '../sinks/collect-all.ts';
+import { pipe } from '../pipe.ts';
+import { map } from '../operators/map.ts';
+import type { Talkback } from '../types.ts';
+
+describe('make', () => {
+  describe('basic functionality', () => {
+    it('should emit values through next', async () => {
+      const source = make<number>((observer) => {
+        observer.next(1);
+        observer.next(2);
+        observer.next(3);
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it('should emit single value', async () => {
+      const source = make<number>((observer) => {
+        observer.next(42);
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([42]);
+    });
+
+    it('should complete without emitting values', () => {
+      const source = make<number>((observer) => {
+        observer.complete();
+        return () => {};
+      });
+
+      let completed = false;
+      const emitted: number[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {
+          completed = true;
+        },
+      });
+
+      expect(emitted).toEqual([]);
+      expect(completed).toBe(true);
+    });
+
+    it('should call teardown function on cancel', () => {
+      const teardown = vi.fn();
+      const source = make<number>((observer) => {
+        observer.next(1);
+        return teardown;
+      });
+
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      expect(teardown).not.toHaveBeenCalled();
+
+      talkback.cancel();
+
+      expect(teardown).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call teardown on asynchronous complete', async () => {
+      const teardown = vi.fn();
+      const source = make<number>((observer) => {
+        observer.next(1);
+        setTimeout(() => {
+          observer.complete();
+        }, 10);
+        return teardown;
+      });
+
+      await new Promise<void>((resolve) => {
+        source({
+          start: () => {},
+          next: () => {},
+          complete: () => {
+            resolve();
+          },
+        });
+      });
+
+      expect(teardown).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cancellation', () => {
+    it('should not emit after cancellation', () => {
+      const source = make<number>((observer) => {
+        observer.next(1);
+        setTimeout(() => {
+          observer.next(2);
+        }, 10);
+        return () => {};
+      });
+
+      const emitted: number[] = [];
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: (value) => {
+          emitted.push(value);
+          if (value === 1) {
+            talkback.cancel();
+          }
+        },
+        complete: () => {},
+      });
+
+      expect(emitted).toEqual([1]);
+    });
+
+    it('should not complete after cancellation', () => {
+      const source = make<number>((observer) => {
+        observer.next(1);
+        setTimeout(() => {
+          observer.complete();
+        }, 10);
+        return () => {};
+      });
+
+      let completed = false;
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+          tb.cancel();
+        },
+        next: () => {},
+        complete: () => {
+          completed = true;
+        },
+      });
+
+      expect(completed).toBe(false);
+    });
+
+    it('should not emit if cancelled before subscriber runs', () => {
+      const source = make<number>((observer) => {
+        observer.next(1);
+        return () => {};
+      });
+
+      const emitted: number[] = [];
+
+      source({
+        start: (tb) => {
+          tb.cancel();
+        },
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      expect(emitted).toEqual([]);
+    });
+
+    it('should call teardown only once on multiple cancels', () => {
+      const teardown = vi.fn();
+      const source = make<number>(() => teardown);
+
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      talkback.cancel();
+      talkback.cancel();
+      talkback.cancel();
+
+      expect(teardown).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('value types', () => {
+    it('should emit strings', async () => {
+      const source = make<string>((observer) => {
+        observer.next('a');
+        observer.next('b');
+        observer.next('c');
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual(['a', 'b', 'c']);
+    });
+
+    it('should emit objects', async () => {
+      const source = make<{ id: number }>((observer) => {
+        observer.next({ id: 1 });
+        observer.next({ id: 2 });
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+    });
+
+    it('should emit arrays', async () => {
+      const source = make<number[]>((observer) => {
+        observer.next([1, 2]);
+        observer.next([3, 4]);
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([
+        [1, 2],
+        [3, 4],
+      ]);
+    });
+  });
+
+  describe('falsy values', () => {
+    it('should emit null', async () => {
+      const source = make<number | null>((observer) => {
+        observer.next(1);
+        observer.next(null);
+        observer.next(2);
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([1, null, 2]);
+    });
+
+    it('should emit undefined', async () => {
+      const source = make<number | undefined>((observer) => {
+        observer.next(1);
+        observer.next(undefined);
+        observer.next(2);
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([1, undefined, 2]);
+    });
+
+    it('should emit zero', async () => {
+      const source = make<number>((observer) => {
+        observer.next(0);
+        observer.next(1);
+        observer.next(0);
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([0, 1, 0]);
+    });
+
+    it('should emit false', async () => {
+      const source = make<boolean>((observer) => {
+        observer.next(false);
+        observer.next(true);
+        observer.next(false);
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([false, true, false]);
+    });
+
+    it('should emit empty string', async () => {
+      const source = make<string>((observer) => {
+        observer.next('');
+        observer.next('a');
+        observer.next('');
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual(['', 'a', '']);
+    });
+  });
+
+  describe('with operators', () => {
+    it('should work with map', async () => {
+      const source = make<number>((observer) => {
+        observer.next(1);
+        observer.next(2);
+        observer.next(3);
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await pipe(
+        source,
+        map((x) => x * 2),
+        collectAll,
+      );
+
+      expect(result).toEqual([2, 4, 6]);
+    });
+
+    it('should work with multiple operators', async () => {
+      const source = make<number>((observer) => {
+        observer.next(1);
+        observer.next(2);
+        observer.next(3);
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await pipe(
+        source,
+        map((x) => x * 2),
+        map((x) => x + 1),
+        collectAll,
+      );
+
+      expect(result).toEqual([3, 5, 7]);
+    });
+  });
+
+  describe('talkback', () => {
+    it('should provide talkback', () => {
+      const source = make<number>(() => () => {});
+      let receivedTalkback: Talkback | null = null;
+
+      source({
+        start: (tb) => {
+          receivedTalkback = tb;
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      expect(receivedTalkback).not.toBeNull();
+      expect(receivedTalkback).toHaveProperty('pull');
+      expect(receivedTalkback).toHaveProperty('cancel');
+    });
+
+    it('should have pull method that does nothing', () => {
+      const source = make<number>(() => () => {});
+
+      source({
+        start: (tb) => {
+          expect(() => tb.pull()).not.toThrow();
+        },
+        next: () => {},
+        complete: () => {},
+      });
+    });
+  });
+
+  describe('asynchronous behavior', () => {
+    it('should handle async emissions', async () => {
+      const source = make<number>((observer) => {
+        setTimeout(() => observer.next(1), 10);
+        setTimeout(() => observer.next(2), 20);
+        setTimeout(() => observer.complete(), 30);
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([1, 2]);
+    });
+
+    it('should handle async with cancellation', async () => {
+      const source = make<number>((observer) => {
+        const timeout1 = setTimeout(() => observer.next(1), 10);
+        const timeout2 = setTimeout(() => observer.next(2), 20);
+
+        return () => {
+          clearTimeout(timeout1);
+          clearTimeout(timeout2);
+        };
+      });
+
+      const emitted: number[] = [];
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 15));
+      talkback.cancel();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(emitted).toEqual([1]);
+    });
+  });
+
+  describe('completion behavior', () => {
+    it('should not emit after complete', () => {
+      const source = make<number>((observer) => {
+        observer.next(1);
+        observer.complete();
+        observer.next(2);
+        return () => {};
+      });
+
+      const emitted: number[] = [];
+
+      source({
+        start: () => {},
+        next: (value) => {
+          emitted.push(value);
+        },
+        complete: () => {},
+      });
+
+      expect(emitted).toEqual([1]);
+    });
+
+    it('should complete only once', () => {
+      const source = make<number>((observer) => {
+        observer.next(1);
+        observer.complete();
+        observer.complete();
+        observer.complete();
+        return () => {};
+      });
+
+      let completeCount = 0;
+
+      source({
+        start: () => {},
+        next: () => {},
+        complete: () => {
+          completeCount++;
+        },
+      });
+
+      expect(completeCount).toBe(1);
+    });
+
+    it('should not call teardown on synchronous complete', () => {
+      const teardown = vi.fn();
+      const source = make<number>((observer) => {
+        observer.complete();
+        return teardown;
+      });
+
+      source({
+        start: () => {},
+        next: () => {},
+        complete: () => {},
+      });
+
+      expect(teardown).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle immediate completion', () => {
+      const source = make<number>((observer) => {
+        observer.complete();
+        return () => {};
+      });
+
+      let completed = false;
+
+      source({
+        start: () => {},
+        next: () => {},
+        complete: () => {
+          completed = true;
+        },
+      });
+
+      expect(completed).toBe(true);
+    });
+
+    it('should handle many values', async () => {
+      const source = make<number>((observer) => {
+        for (let i = 0; i < 1000; i++) {
+          observer.next(i);
+        }
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result.length).toBe(1000);
+      expect(result[0]).toBe(0);
+      expect(result[999]).toBe(999);
+    });
+
+    it('should handle complex objects', async () => {
+      const source = make<{ id: number; data: { nested: string } }>((observer) => {
+        observer.next({ id: 1, data: { nested: 'a' } });
+        observer.next({ id: 2, data: { nested: 'b' } });
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([
+        { id: 1, data: { nested: 'a' } },
+        { id: 2, data: { nested: 'b' } },
+      ]);
+    });
+
+    it('should handle teardown that throws', () => {
+      const source = make<number>(() => {
+        return () => {
+          throw new Error('teardown error');
+        };
+      });
+
+      let talkback: Talkback;
+
+      source({
+        start: (tb) => {
+          talkback = tb;
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      expect(() => talkback.cancel()).toThrow('teardown error');
+    });
+
+    it('should handle subscriber that throws', () => {
+      const source = make<number>(() => {
+        throw new Error('subscriber error');
+      });
+
+      expect(() => {
+        source({
+          start: () => {},
+          next: () => {},
+          complete: () => {},
+        });
+      }).toThrow('subscriber error');
+    });
+
+    it('should not run subscriber if cancelled before', () => {
+      const subscriber = vi.fn(() => () => {});
+      const source = make(subscriber);
+
+      source({
+        start: (tb) => {
+          tb.cancel();
+        },
+        next: () => {},
+        complete: () => {},
+      });
+
+      expect(subscriber).not.toHaveBeenCalled();
+    });
+
+    it('should handle NaN values', async () => {
+      const source = make<number>((observer) => {
+        observer.next(Number.NaN);
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result[0]).toBeNaN();
+    });
+
+    it('should handle Infinity values', async () => {
+      const source = make<number>((observer) => {
+        observer.next(Infinity);
+        observer.next(-Infinity);
+        observer.complete();
+        return () => {};
+      });
+
+      const result = await collectAll(source);
+
+      expect(result).toEqual([Infinity, -Infinity]);
+    });
+  });
+});


### PR DESCRIPTION
Add test suites for delay operator and fromPromise, fromSubscription, make sources.

- delay operator: timing, cancellation, various value types
- fromPromise source: promise resolution/rejection, cancellation, async behavior
- fromSubscription source: initial values, signal updates, cleanup
- make source: observer pattern, teardown, async emissions

All 110 tests passing