### PR TITLE
fix(pkg): move out internal packages into separated scope

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@mearie/docs", "@mearie/fixture", "@mearie/examples-*"]
+  "ignore": ["!@mearie/*"]
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mearie/docs",
+  "name": "@mearie-internal/docs",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mearie/examples-basic",
+  "name": "@mearie-internal/examples-basic",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/examples/server/package.json
+++ b/examples/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mearie/examples-server",
+  "name": "@mearie-internal/examples-server",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -8,7 +8,7 @@
     "release": "wrangler deploy"
   },
   "dependencies": {
-    "@mearie/fixture": "workspace:*",
+    "@mearie-internal/fixture": "workspace:*",
     "graphql-yoga": "^5.16.0"
   },
   "devDependencies": {

--- a/fixture/package.json
+++ b/fixture/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mearie/fixture",
+  "name": "@mearie-internal/fixture",
   "version": "0.0.0",
   "private": true,
   "description": "Spotify music dataset fixture for Mearie examples and tests",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mearie/monorepo",
+  "name": "@mearie-internal/monorepo",
   "version": "0.0.0",
   "private": true,
   "description": "Type-safe, zero-overhead GraphQL client",
@@ -27,9 +27,9 @@
   "sideEffects": false,
   "type": "module",
   "scripts": {
-    "build": "turbo build --filter=!@mearie/docs --filter=!@mearie/examples-*",
-    "build:docs": "turbo build --filter=@mearie/docs",
-    "build:examples": "turbo build --filter=@mearie/examples-*",
+    "build": "turbo build --filter=!@mearie-internal/*",
+    "build:docs": "turbo build --filter=@mearie-internal/docs",
+    "build:examples": "turbo build --filter=@mearie-internal/examples-*",
     "changeset": "changeset",
     "changeset:publish": "changeset publish",
     "changeset:version": "changeset version",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,7 +119,7 @@ importers:
 
   examples/server:
     dependencies:
-      '@mearie/fixture':
+      '@mearie-internal/fixture':
         specifier: workspace:*
         version: link:../../fixture
       graphql-yoga:


### PR DESCRIPTION
Move out internal packages such as docs, examples and fixtures into separated scope (`@mearie-internal`) for better organization.