### PR TITLE
fix(changeset): add `mearie` main package into not-ignored packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["!@mearie/*"]
+  "ignore": ["!(@mearie/*|mearie)"]
 }


### PR DESCRIPTION
That was missing from #57.