### PR TITLE
fix(core): fix wrong body field name for artifacts

### DIFF
--- a/packages/core/src/exchanges/http.ts
+++ b/packages/core/src/exchanges/http.ts
@@ -50,7 +50,7 @@ const executeFetch = async (
         ...fetchOptions.headers,
       },
       body: JSON.stringify({
-        query: artifact.source,
+        query: artifact.body,
         variables,
       }),
     });

--- a/packages/core/src/exchanges/subscription.ts
+++ b/packages/core/src/exchanges/subscription.ts
@@ -84,7 +84,7 @@ export const subscriptionExchange = (options: SubscriptionExchangeOptions): Exch
           const source = make<OperationResult>((observer) =>
             client.subscribe(
               {
-                query: op.artifact.source,
+                query: op.artifact.body,
                 variables: op.variables as Record<string, unknown>,
               },
               {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -25,7 +25,7 @@ export type Artifact<
 > = {
   readonly kind: Kind;
   readonly name: Name;
-  readonly source: string;
+  readonly body: string;
   readonly selections: readonly Selection[];
 
   readonly ' $data'?: Data;


### PR DESCRIPTION
Fixes wrong body field name on `Artifact`.