### PR TITLE
fix(react): use stable variables for query and subscription

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,3 +37,5 @@ export {
   type SubscriptionOptions,
   type FragmentOptions,
 } from './client.ts';
+
+export { stringify } from './utils.ts';

--- a/packages/react/src/use-query.ts
+++ b/packages/react/src/use-query.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Artifact, DataOf, QueryOptions, VariablesOf } from '@mearie/core';
-import { AggregatedError } from '@mearie/core';
+import { AggregatedError, stringify } from '@mearie/core';
 import { pipe, subscribe } from '@mearie/core/stream';
 import { useClient } from './client-provider.tsx';
 
@@ -41,6 +41,7 @@ export const useQuery = <T extends Artifact<'query'>>(
   const [error, setError] = useState<AggregatedError | undefined>();
 
   const unsubscribe = useRef<(() => void) | null>(null);
+  const stableVariables = useMemo(() => stringify(variables), [variables]);
   const stableOptions = useMemo(() => options, [options?.skip]);
 
   const execute = useCallback(() => {
@@ -69,7 +70,7 @@ export const useQuery = <T extends Artifact<'query'>>(
         },
       }),
     );
-  }, [client, query, variables, stableOptions]);
+  }, [client, query, stableVariables, stableOptions]);
 
   useEffect(() => {
     execute();

--- a/packages/react/src/use-subscription.ts
+++ b/packages/react/src/use-subscription.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { VariablesOf, DataOf, Artifact, SubscriptionOptions } from '@mearie/core';
-import { AggregatedError } from '@mearie/core';
+import { AggregatedError, stringify } from '@mearie/core';
 import { pipe, subscribe } from '@mearie/core/stream';
 import { useClient } from './client-provider.tsx';
 
@@ -40,6 +40,7 @@ export const useSubscription = <T extends Artifact<'subscription'>>(
   const [error, setError] = useState<AggregatedError | undefined>();
 
   const unsubscribe = useRef<(() => void) | null>(null);
+  const stableVariables = useMemo(() => stringify(variables), [variables]);
   const stableOptions = useMemo(() => options, [options?.skip, options?.onData, options?.onError]);
 
   const execute = useCallback(() => {
@@ -76,7 +77,7 @@ export const useSubscription = <T extends Artifact<'subscription'>>(
         },
       }),
     );
-  }, [client, subscription, variables, stableOptions]);
+  }, [client, subscription, stableVariables, stableOptions]);
 
   useEffect(() => {
     execute();


### PR DESCRIPTION
Use stable-variant of variables for query and subscriptions in the React bindings as React compares the dependency with reference identity.

The current implementation uses `stringify` from `@mearie/core`, but it should use the artifact-optimized variables serializer in the future.