### PR TITLE
fix(core): tsdown build output path for stream entry point

### DIFF
--- a/.changeset/hot-waves-wear.md
+++ b/.changeset/hot-waves-wear.md
@@ -1,0 +1,5 @@
+---
+'@mearie/core': patch
+---
+
+fix(core): tsdown build output path for stream entry point

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mearie/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sideEffects": false,
   "type": "module",
   "exports": {

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -3,4 +3,8 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
   format: ['esm', 'cjs'],
   dts: true,
+  entry: {
+    index: 'src/index.ts',
+    'stream/index': 'src/stream/index.ts',
+  },
 });


### PR DESCRIPTION
## Overview
- `tsdown` 빌드 시 [stream](cci:7://file:///Users/robin/Projects/mearie/packages/core/src/stream:0:0-0:0) 엔트리 포인트가 `dist/stream.*`로 생성되는 문제 수정
- [package.json](cci:7://file:///Users/robin/Projects/mearie/packages/core/package.json:0:0-0:0)의 `publishConfig.exports`와 일치하도록 출력 경로 수정

## Problem
- [package.json](cci:7://file:///Users/robin/Projects/mearie/packages/core/package.json:0:0-0:0)에서 `"./stream": "./dist/stream/index.*"`로 설정되어 있었음
- 하지만 `tsdown`이 `dist/stream.*`를 생성하여 경로 불일치 발생

## Solution
- [tsdown.config.ts](cci:7://file:///Users/robin/Projects/mearie/packages/core/tsdown.config.ts:0:0-0:0)에서 엔트리 키를 [stream](cci:7://file:///Users/robin/Projects/mearie/packages/core/src/stream:0:0-0:0)에서 `'stream/index'`로 수정
- 이제 `dist/stream/index.*` 파일이 정상적으로 생성됨

## Changes
- [packages/core/tsdown.config.ts](cci:7://file:///Users/robin/Projects/mearie/packages/core/tsdown.config.ts:0:0-0:0): 엔트리 경로 수정

## Verification
- ✅ `pnpm run build` 실행 확인
- ✅ [dist/stream/index.d.ts](cci:7://file:///Users/robin/Projects/mearie/packages/core/dist/stream/index.d.ts:0:0-0:0), [dist/stream/index.js](cci:7://file:///Users/robin/Projects/mearie/packages/core/dist/stream/index.js:0:0-0:0), [dist/stream/index.cjs](cci:7://file:///Users/robin/Projects/mearie/packages/core/dist/stream/index.cjs:0:0-0:0) 생성 확인
- ✅ [package.json](cci:7://file:///Users/robin/Projects/mearie/packages/core/package.json:0:0-0:0)의 `publishConfig.exports`와 경로 일치 확인