### PR TITLE
[codex] Add React Suspense query support

### DIFF
--- a/.changeset/proud-donuts-sink.md
+++ b/.changeset/proud-donuts-sink.md
@@ -1,0 +1,5 @@
+---
+'@mearie/react': minor
+---
+
+Add React Suspense support to `useQuery` via the `suspense: true` option.

--- a/packages/react/src/use-query.test.ts
+++ b/packages/react/src/use-query.test.ts
@@ -1,8 +1,29 @@
-import { describe, it, expect } from 'vitest';
-import { act } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { Component, Suspense, createElement, act, useState, type ReactNode } from 'react';
+import { createRoot } from 'react-dom/client';
 import { AggregatedError } from '@mearie/core';
 import { useQuery } from './use-query.ts';
+import { ClientProvider } from './client-provider.tsx';
 import { createMockClient, renderHook, mockQuery, makeResult } from './test-utils.ts';
+
+class TestErrorBoundary extends Component<
+  { children?: ReactNode; onError: (error: unknown) => void },
+  { hasError: boolean }
+> {
+  override state = { hasError: false };
+
+  static getDerivedStateFromError(): { hasError: boolean } {
+    return { hasError: true };
+  }
+
+  override componentDidCatch(error: unknown): void {
+    this.props.onError(error);
+  }
+
+  override render(): ReactNode {
+    return this.state.hasError ? createElement('div', null, 'errored') : this.props.children;
+  }
+}
 
 describe('useQuery', () => {
   it('should transition from loading to data', () => {
@@ -168,5 +189,380 @@ describe('useQuery', () => {
 
     expect(result.current.metadata).toEqual(testMetadata);
     unmount();
+  });
+
+  it('should suspend until the first query result resolves when suspense is true', async () => {
+    const { client, subjects } = createMockClient();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    const TestComponent = (): ReactNode => {
+      const { data } = useQuery(mockQuery, undefined, { suspense: true });
+      return createElement('div', null, (data as { name: string }).name);
+    };
+
+    act(() => {
+      root.render(
+        createElement(ClientProvider, {
+          client,
+          children: createElement(
+            Suspense,
+            { fallback: createElement('div', null, 'loading') },
+            createElement(TestComponent),
+          ),
+        }),
+      );
+    });
+
+    expect(container.textContent).toContain('loading');
+
+    await act(async () => {
+      subjects.query.next(makeResult({ id: '1', name: 'Alice' }));
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe('Alice');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(client.executeQuery).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      subjects.query.next(makeResult({ id: '1', name: 'Bob' }));
+    });
+
+    expect(container.textContent).toBe('Bob');
+    act(() => root.unmount());
+  });
+
+  it('should refresh in the background when suspense and initialData are provided', () => {
+    const { client, subjects } = createMockClient();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    const TestComponent = (): ReactNode => {
+      const { data } = useQuery(mockQuery, undefined, {
+        suspense: true,
+        initialData: { id: '1', name: 'Prefetched' },
+      });
+      return createElement('div', null, (data as { name: string }).name);
+    };
+
+    act(() => {
+      root.render(
+        createElement(ClientProvider, {
+          client,
+          children: createElement(
+            Suspense,
+            { fallback: createElement('div', null, 'loading') },
+            createElement(TestComponent),
+          ),
+        }),
+      );
+    });
+
+    expect(container.textContent).toBe('Prefetched');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(client.executeQuery).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      subjects.query.next(makeResult({ id: '1', name: 'Updated' }));
+    });
+
+    expect(container.textContent).toBe('Updated');
+    act(() => root.unmount());
+  });
+
+  it('should use each caller initialData when suspense and initialData are provided', () => {
+    const { client } = createMockClient();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+
+    const TestComponent = ({ name }: { name: string }): ReactNode => {
+      const { data } = useQuery(mockQuery, undefined, {
+        suspense: true,
+        initialData: { id: '1', name },
+      });
+      return createElement('div', null, (data as { name: string }).name);
+    };
+
+    act(() => {
+      root.render(
+        createElement(ClientProvider, {
+          client,
+          children: createElement(
+            Suspense,
+            { fallback: createElement('div', null, 'loading') },
+            createElement(TestComponent, { key: 'first', name: 'First' }),
+          ),
+        }),
+      );
+    });
+
+    expect(container.textContent).toBe('First');
+
+    act(() => {
+      root.render(
+        createElement(ClientProvider, {
+          client,
+          children: createElement(
+            Suspense,
+            { fallback: createElement('div', null, 'loading') },
+            createElement(TestComponent, { key: 'second', name: 'Second' }),
+          ),
+        }),
+      );
+    });
+
+    expect(container.textContent).toBe('Second');
+    act(() => root.unmount());
+  });
+
+  it('should not start duplicate suspense queries when variables change', async () => {
+    const { client, subjects } = createMockClient();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    let setUserId: (userId: string) => void = () => {};
+
+    const TestComponent = (): ReactNode => {
+      const [userId, setStateUserId] = useState('1');
+      setUserId = setStateUserId;
+      const { data } = useQuery(mockQuery, { id: userId } as never, { suspense: true });
+      return createElement('div', null, (data as { name: string }).name);
+    };
+
+    act(() => {
+      root.render(
+        createElement(ClientProvider, {
+          client,
+          children: createElement(
+            Suspense,
+            { fallback: createElement('div', null, 'loading') },
+            createElement(TestComponent),
+          ),
+        }),
+      );
+    });
+
+    await act(async () => {
+      subjects.query.next(makeResult({ id: '1', name: 'Alice' }));
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe('Alice');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(client.executeQuery).toHaveBeenCalledTimes(1);
+
+    act(() => setUserId('2'));
+
+    expect(container.textContent).toContain('loading');
+
+    await act(async () => {
+      subjects.query.next(makeResult({ id: '2', name: 'Bob' }));
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe('Bob');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(client.executeQuery).toHaveBeenCalledTimes(2);
+    act(() => root.unmount());
+  });
+
+  it('should throw query errors to an error boundary when suspense is true', async () => {
+    const { client, subjects } = createMockClient();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let caughtError: unknown;
+
+    const TestComponent = (): ReactNode => {
+      useQuery(mockQuery, undefined, { suspense: true });
+      return createElement('div', null, 'loaded');
+    };
+
+    act(() => {
+      root.render(
+        createElement(ClientProvider, {
+          client,
+          children: createElement(
+            TestErrorBoundary,
+            { onError: (error) => (caughtError = error) },
+            createElement(Suspense, { fallback: createElement('div', null, 'loading') }, createElement(TestComponent)),
+          ),
+        }),
+      );
+    });
+
+    await act(async () => {
+      subjects.query.next(makeResult(undefined, { errors: [{ message: 'Not found' }] }));
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe('errored');
+    expect(caughtError).toBeInstanceOf(AggregatedError);
+    act(() => root.unmount());
+    consoleError.mockRestore();
+  });
+
+  it('should throw when a suspense query completes without a result', async () => {
+    const { client, subjects } = createMockClient();
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let caughtError: unknown;
+
+    const TestComponent = (): ReactNode => {
+      useQuery(mockQuery, undefined, { suspense: true });
+      return createElement('div', null, 'loaded');
+    };
+
+    act(() => {
+      root.render(
+        createElement(ClientProvider, {
+          client,
+          children: createElement(
+            TestErrorBoundary,
+            { onError: (error) => (caughtError = error) },
+            createElement(Suspense, { fallback: createElement('div', null, 'loading') }, createElement(TestComponent)),
+          ),
+        }),
+      );
+    });
+
+    await act(async () => {
+      subjects.query.complete();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toBe('errored');
+    expect(caughtError).toBeInstanceOf(Error);
+    expect((caughtError as Error).message).toBe('Query completed without emitting a result');
+    act(() => root.unmount());
+    consoleError.mockRestore();
+  });
+
+  it('should keep suspense resource data current after patch updates', async () => {
+    const { client, subjects } = createMockClient();
+    const firstContainer = document.createElement('div');
+    const firstRoot = createRoot(firstContainer);
+
+    const TestComponent = (): ReactNode => {
+      const { data } = useQuery(mockQuery, undefined, { suspense: true });
+      return createElement('div', null, (data as { name: string }).name);
+    };
+
+    act(() => {
+      firstRoot.render(
+        createElement(ClientProvider, {
+          client,
+          children: createElement(
+            Suspense,
+            { fallback: createElement('div', null, 'loading') },
+            createElement(TestComponent),
+          ),
+        }),
+      );
+    });
+
+    await act(async () => {
+      subjects.query.next(makeResult({ id: '1', name: 'Alice' }));
+      await Promise.resolve();
+    });
+
+    act(() => {
+      subjects.query.next(
+        makeResult(undefined, {
+          metadata: {
+            cache: {
+              patches: [{ type: 'set', path: ['name'], value: 'Patched' }],
+            },
+          },
+        }),
+      );
+    });
+
+    expect(firstContainer.textContent).toBe('Patched');
+    act(() => firstRoot.unmount());
+
+    const secondContainer = document.createElement('div');
+    const secondRoot = createRoot(secondContainer);
+
+    act(() => {
+      secondRoot.render(
+        createElement(ClientProvider, {
+          client,
+          children: createElement(
+            Suspense,
+            { fallback: createElement('div', null, 'loading') },
+            createElement(TestComponent),
+          ),
+        }),
+      );
+    });
+
+    expect(secondContainer.textContent).toBe('Patched');
+    act(() => secondRoot.unmount());
+  });
+
+  it('should retry suspense queries after an error boundary reset', async () => {
+    const { client, subjects } = createMockClient();
+    const firstContainer = document.createElement('div');
+    const firstRoot = createRoot(firstContainer);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let caughtError: unknown;
+
+    const TestComponent = (): ReactNode => {
+      const { data } = useQuery(mockQuery, undefined, { suspense: true });
+      return createElement('div', null, (data as { name: string }).name);
+    };
+
+    act(() => {
+      firstRoot.render(
+        createElement(ClientProvider, {
+          client,
+          children: createElement(
+            TestErrorBoundary,
+            { onError: (error) => (caughtError = error) },
+            createElement(Suspense, { fallback: createElement('div', null, 'loading') }, createElement(TestComponent)),
+          ),
+        }),
+      );
+    });
+
+    await act(async () => {
+      subjects.query.next(makeResult(undefined, { errors: [{ message: 'Temporary failure' }] }));
+      await Promise.resolve();
+    });
+
+    expect(firstContainer.textContent).toBe('errored');
+    expect(caughtError).toBeInstanceOf(AggregatedError);
+    act(() => firstRoot.unmount());
+
+    const secondContainer = document.createElement('div');
+    const secondRoot = createRoot(secondContainer);
+
+    act(() => {
+      secondRoot.render(
+        createElement(ClientProvider, {
+          client,
+          children: createElement(
+            Suspense,
+            { fallback: createElement('div', null, 'loading') },
+            createElement(TestComponent),
+          ),
+        }),
+      );
+    });
+
+    expect(secondContainer.textContent).toBe('loading');
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(client.executeQuery).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      subjects.query.next(makeResult({ id: '1', name: 'Recovered' }));
+      await Promise.resolve();
+    });
+
+    expect(secondContainer.textContent).toBe('Recovered');
+    act(() => secondRoot.unmount());
+    consoleError.mockRestore();
   });
 });

--- a/packages/react/src/use-query.ts
+++ b/packages/react/src/use-query.ts
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { Artifact, DataOf, OperationResult, QueryOptions, VariablesOf } from '@mearie/core';
+import type { Artifact, Client, DataOf, OperationResult, QueryOptions, SchemaMeta, VariablesOf } from '@mearie/core';
 import { AggregatedError, stringify, applyPatchesImmutable } from '@mearie/core';
 import { pipe, subscribe } from '@mearie/core/stream';
 import { useClient } from './client-provider.tsx';
 
 export type UseQueryOptions<T extends Artifact<'query'> = Artifact<'query'>> = QueryOptions<T> & {
   skip?: boolean;
+  suspense?: boolean;
 };
 
 export type Query<T extends Artifact<'query'>> =
@@ -58,6 +59,11 @@ type UseQueryFn = {
   <T extends Artifact<'query'>>(
     query: T,
     variables: VariablesOf<T> | undefined,
+    options: UseQueryOptions<T> & { suspense: true; skip?: false },
+  ): DefinedQuery<T>;
+  <T extends Artifact<'query'>>(
+    query: T,
+    variables: VariablesOf<T> | undefined,
     options: UseQueryOptions<T> & { initialData: DataOf<T> },
   ): DefinedQuery<T>;
   <T extends Artifact<'query'>>(
@@ -68,15 +74,212 @@ type UseQueryFn = {
   ): Query<T>;
 };
 
+type SuspenseQueryResource<T> = {
+  status: 'pending' | 'success' | 'error';
+  promise: Promise<void>;
+  data: T | undefined;
+  error: Error | undefined;
+  result: OperationResult | undefined;
+  active: boolean;
+  subscribe: (listener: (result: OperationResult) => void) => () => void;
+};
+
+const suspenseQueryCache = new WeakMap<Client<SchemaMeta>, Map<string, SuspenseQueryResource<unknown>>>();
+
+const getSuspenseQueryKey = <T extends Artifact<'query'>>(
+  query: T,
+  variables: VariablesOf<T> | undefined,
+  options: UseQueryOptions<T> | undefined,
+): string => {
+  return stringify([query, variables, options?.metadata]);
+};
+
+const getSuspenseQueryResource = <T extends Artifact<'query'>>(
+  client: Client<SchemaMeta>,
+  query: T,
+  variables: VariablesOf<T> | undefined,
+  options: UseQueryOptions<T> | undefined,
+  key: string,
+): SuspenseQueryResource<DataOf<T>> => {
+  let clientCache = suspenseQueryCache.get(client);
+  if (!clientCache) {
+    clientCache = new Map();
+    suspenseQueryCache.set(client, clientCache);
+  }
+
+  const cached = clientCache.get(key);
+  if (cached) {
+    return cached as SuspenseQueryResource<DataOf<T>>;
+  }
+
+  const queryOptions: QueryOptions<T> = {
+    metadata: options?.metadata,
+    signal: options?.signal,
+  };
+
+  const listeners = new Set<(result: OperationResult) => void>();
+  let cleanup: (() => void) | undefined;
+  let unusedCleanupTimer: ReturnType<typeof setTimeout> | undefined;
+  let resolveFirstResult: () => void;
+
+  const scheduleUnusedCleanup = (): void => {
+    if (unusedCleanupTimer) return;
+
+    unusedCleanupTimer = setTimeout(() => {
+      unusedCleanupTimer = undefined;
+      if (listeners.size > 0) return;
+
+      cleanup?.();
+      cleanup = undefined;
+      resource.active = false;
+      clientCache.delete(key);
+    }, 0);
+  };
+
+  const resource: SuspenseQueryResource<DataOf<T>> = {
+    status: 'pending',
+    promise: new Promise((resolve) => {
+      resolveFirstResult = resolve;
+    }),
+    data: undefined,
+    error: undefined,
+    result: undefined,
+    active: true,
+    subscribe: (listener) => {
+      if (unusedCleanupTimer) {
+        clearTimeout(unusedCleanupTimer);
+        unusedCleanupTimer = undefined;
+      }
+
+      if (resource.result) {
+        listener(resource.result);
+      }
+
+      listeners.add(listener);
+
+      return () => {
+        listeners.delete(listener);
+        if (listeners.size === 0) {
+          cleanup?.();
+          cleanup = undefined;
+          resource.active = false;
+        }
+      };
+    },
+  };
+
+  cleanup = pipe(
+    // @ts-expect-error - conditional signature makes this hard to type correctly
+    client.executeQuery(query, variables, queryOptions),
+    subscribe({
+      next: (result) => {
+        resource.result = result;
+
+        if (resource.status === 'pending') {
+          if (result.errors && result.errors.length > 0) {
+            resource.status = 'error';
+            resource.error = new AggregatedError(result.errors);
+            cleanup?.();
+            cleanup = undefined;
+            resource.active = false;
+          } else {
+            resource.status = 'success';
+            const patches = result.metadata?.cache?.patches;
+            resource.data = patches ? applyPatchesImmutable(resource.data, patches)! : (result.data as DataOf<T>);
+          }
+
+          resolveFirstResult();
+          scheduleUnusedCleanup();
+        } else if (!result.errors || result.errors.length === 0) {
+          const patches = result.metadata?.cache?.patches;
+          resource.data = patches ? applyPatchesImmutable(resource.data, patches)! : (result.data as DataOf<T>);
+        }
+
+        for (const listener of listeners) {
+          listener(result);
+        }
+      },
+      complete: () => {
+        if (resource.status === 'pending') {
+          resource.status = 'error';
+          resource.error = new Error('Query completed without emitting a result');
+          resolveFirstResult();
+          scheduleUnusedCleanup();
+        }
+        resource.active = false;
+      },
+    }),
+  );
+
+  clientCache.set(key, resource);
+  return resource;
+};
+
+const deleteSuspenseQueryResource = (client: Client<SchemaMeta>, key: string): void => {
+  suspenseQueryCache.get(client)?.delete(key);
+};
+
+const readSuspenseQueryResource = <T>(resource: SuspenseQueryResource<T>, onError?: () => void): T => {
+  switch (resource.status) {
+    case 'pending': {
+      // eslint-disable-next-line @typescript-eslint/only-throw-error -- React Suspense expects pending promises to be thrown during render.
+      throw resource.promise;
+    }
+    case 'error': {
+      if (onError) {
+        queueMicrotask(onError);
+      }
+      throw resource.error!;
+    }
+    case 'success': {
+      return resource.data!;
+    }
+  }
+};
+
+const applyQueryResult = <T extends Artifact<'query'>>(
+  result: OperationResult,
+  setMetadata: (metadata: OperationResult['metadata']) => void,
+  setError: (error: AggregatedError | undefined) => void,
+  setLoading: (loading: boolean) => void,
+  setData: (updater: DataOf<T> | ((prev: DataOf<T> | undefined) => DataOf<T>)) => void,
+): void => {
+  setMetadata(result.metadata);
+  if (result.errors && result.errors.length > 0) {
+    setError(new AggregatedError(result.errors));
+    setLoading(false);
+  } else {
+    const patches = result.metadata?.cache?.patches;
+    if (patches) {
+      setData((prev) => applyPatchesImmutable(prev, patches)!);
+    } else {
+      setData(result.data as DataOf<T>);
+    }
+    setLoading(false);
+    setError(undefined);
+  }
+};
+
 export const useQuery: UseQueryFn = (<T extends Artifact<'query'>>(
   query: T,
   variables?: VariablesOf<T>,
   options?: UseQueryOptions<T>,
 ): Query<T> => {
   const client = useClient();
+  const suspenseKey =
+    options?.suspense && !options.skip && options.initialData === undefined
+      ? getSuspenseQueryKey(query, variables, options)
+      : undefined;
+  const suspenseResource =
+    suspenseKey === undefined ? undefined : getSuspenseQueryResource(client, query, variables, options, suspenseKey);
+  const suspenseData =
+    suspenseKey === undefined
+      ? undefined
+      : readSuspenseQueryResource(suspenseResource!, () => deleteSuspenseQueryResource(client, suspenseKey));
+  const hasInitialData = options?.initialData !== undefined || suspenseData !== undefined;
 
-  const [data, setData] = useState<DataOf<T> | undefined>(options?.initialData);
-  const [loading, setLoading] = useState(!options?.skip && !options?.initialData);
+  const [data, setData] = useState<DataOf<T> | undefined>(suspenseData ?? options?.initialData);
+  const [loading, setLoading] = useState(!options?.skip && !hasInitialData);
   const [error, setError] = useState<AggregatedError | undefined>();
   const [metadata, setMetadata] = useState<OperationResult['metadata']>();
 
@@ -84,6 +287,12 @@ export const useQuery: UseQueryFn = (<T extends Artifact<'query'>>(
   const initialized = useRef(false);
   const stableVariables = useMemo(() => stringify(variables), [variables]);
   const stableOptions = useMemo(() => options, [options?.skip]);
+  const activeSuspenseKey = useRef(suspenseKey);
+  const activeSuspenseResource = useRef<SuspenseQueryResource<DataOf<T>> | undefined>(suspenseResource);
+
+  const handleResult = useCallback((result: OperationResult) => {
+    applyQueryResult<T>(result, setMetadata, setError, setLoading, setData);
+  }, []);
 
   const execute = useCallback(
     (force = false) => {
@@ -94,7 +303,7 @@ export const useQuery: UseQueryFn = (<T extends Artifact<'query'>>(
         return;
       }
 
-      if (initialized.current || !options?.initialData) {
+      if (initialized.current || !hasInitialData) {
         setLoading(true);
       }
 
@@ -105,37 +314,39 @@ export const useQuery: UseQueryFn = (<T extends Artifact<'query'>>(
         // @ts-expect-error - conditional signature makes this hard to type correctly
         client.executeQuery(query, variables, stableOptions),
         subscribe({
-          next: (result) => {
-            setMetadata(result.metadata);
-            if (result.errors && result.errors.length > 0) {
-              setError(new AggregatedError(result.errors));
-              setLoading(false);
-            } else {
-              const patches = result.metadata?.cache?.patches;
-              if (patches) {
-                setData((prev) => applyPatchesImmutable(prev, patches)!);
-              } else {
-                setData(result.data as DataOf<T>);
-              }
-              setLoading(false);
-              setError(undefined);
-            }
-          },
+          next: handleResult,
         }),
       );
     },
-    [client, query, stableVariables, stableOptions],
+    [client, query, stableVariables, stableOptions, hasInitialData, handleResult],
   );
 
   const refetch = useCallback(() => execute(true), [execute]);
 
   useEffect(() => {
+    if (suspenseKey !== activeSuspenseKey.current) {
+      activeSuspenseKey.current = suspenseKey;
+      activeSuspenseResource.current = suspenseResource;
+      initialized.current = false;
+      setData(suspenseData);
+      setLoading(false);
+      setError(undefined);
+    }
+
+    if (suspenseResource?.active && suspenseResource === activeSuspenseResource.current && !initialized.current) {
+      initialized.current = true;
+      setError(undefined);
+      setLoading(false);
+      unsubscribe.current = suspenseResource.subscribe(handleResult);
+      return () => unsubscribe.current?.();
+    }
+
     execute();
     return () => unsubscribe.current?.();
-  }, [execute]);
+  }, [execute, suspenseKey, suspenseData, suspenseResource, handleResult]);
 
   return {
-    data,
+    data: suspenseKey === activeSuspenseKey.current ? data : suspenseData,
     loading,
     error,
     metadata,


### PR DESCRIPTION
## Summary
- Draft implementation of React Suspense support for `@mearie/react`'s `useQuery` via the documented `suspense: true` option.
- The current branch proves the basic behavior: initial suspension, successful resolution, error-boundary propagation, background updates, patch updates, `initialData` behavior, variable changes, and refetch behavior.
- This PR is intentionally back in draft because review found a deeper ownership problem in the current approach.

## Current blocker
The hard part is request ownership during React render.

To make Suspense work, `useQuery` has to provide React with a pending promise during render. The attempted implementation does that by creating a Suspense resource and starting `client.executeQuery(...)` from the render path. However, if that suspended render is abandoned before commit, React never runs the effect cleanup. That leaves no reliable owner for the stream subscription and can leak the pending query operation/cache entry.

Several follow-up fixes handled adjacent issues such as duplicate queries, stale Suspense resources, refetch behavior, patch updates, `AbortSignal` keying, and client changes. But the abandoned-render cleanup issue remains structural: without moving ownership into a lower-level client/cache resource manager, or using a React-supported cache/disposal mechanism, the hook cannot reliably start a long-lived stream during render and guarantee teardown.

## Likely next direction
- Do not merge the current hook-only Suspense implementation as-is.
- Either update the documentation to stop claiming React Suspense support for now, or design a proper Suspense-aware query resource in the client/cache layer with explicit ownership, ref-counting, replay, abort, and GC semantics.
- If Suspense support remains a goal, the React hook should consume that resource instead of owning a stream subscription started during render.

## Validation so far
- `pnpm exec eslint packages/react/src/use-query.ts packages/react/src/use-query.test.ts`
- `pnpm --filter @mearie/react typecheck`
- `pnpm --filter @mearie/react exec vitest run src/use-query.test.ts`
