### PR TITLE
refactor(native): collapse if-in-match branches into match guards

### DIFF
--- a/crates/native/src/validation/rules/values.rs
+++ b/crates/native/src/validation/rules/values.rs
@@ -198,18 +198,14 @@ impl<'a, 'b> ValueRules<'a, 'b> {
                     );
                 }
             }
-            Value::Int(_) => {
-                if type_name != "Int" && type_name != "Float" {
-                    ctx.add_error(format!("Expected type '{}', but got Int value", type_name), value_span);
-                }
+            Value::Int(_) if type_name != "Int" && type_name != "Float" => {
+                ctx.add_error(format!("Expected type '{}', but got Int value", type_name), value_span);
             }
-            Value::Float(_) => {
-                if type_name != "Float" {
-                    ctx.add_error(
-                        format!("Expected type '{}', but got Float value", type_name),
-                        value_span,
-                    );
-                }
+            Value::Float(_) if type_name != "Float" => {
+                ctx.add_error(
+                    format!("Expected type '{}', but got Float value", type_name),
+                    value_span,
+                );
             }
             Value::String(_) => {
                 let is_built_in_scalar = type_name == "Int" || type_name == "Float" || type_name == "Boolean";
@@ -225,13 +221,11 @@ impl<'a, 'b> ValueRules<'a, 'b> {
                     );
                 }
             }
-            Value::Boolean(_) => {
-                if type_name != "Boolean" {
-                    ctx.add_error(
-                        format!("Expected type '{}', but got Boolean value", type_name),
-                        value_span,
-                    );
-                }
+            Value::Boolean(_) if type_name != "Boolean" => {
+                ctx.add_error(
+                    format!("Expected type '{}', but got Boolean value", type_name),
+                    value_span,
+                );
             }
             _ => {}
         }

--- a/crates/native/src/validation/rules/variables.rs
+++ b/crates/native/src/validation/rules/variables.rs
@@ -136,12 +136,8 @@ impl<'a, 'b> VariableRules<'a, 'b> {
             (Type::NonNull(var_inner), loc_type) => {
                 self.is_type_compatible_non_null_to_nullable(var_inner, loc_type, has_default_value)
             }
-            (var_type, Type::NonNull(loc_inner)) => {
-                if has_default_value {
-                    self.is_type_compatible_nullable_with_default(var_type, loc_inner)
-                } else {
-                    false
-                }
+            (var_type, Type::NonNull(loc_inner)) if has_default_value => {
+                self.is_type_compatible_nullable_with_default(var_type, loc_inner)
             }
             (Type::List(var_inner), Type::List(loc_inner)) => {
                 self.is_type_compatible(var_inner, loc_inner, has_default_value)


### PR DESCRIPTION
clippy reported collapsible_match warnings on four match arms in the GraphQL validation rules where an `if` was the sole body of a match arm. With `-D warnings` in CI, this fails the lint job.

The arms have been rewritten to use match guards instead. Behavior is preserved in every case:

- `values.rs` (`Value::Int`, `Value::Float`, `Value::Boolean` arms): the inner `if` had no else branch, so a falling-through guard simply produces the same no-op result via the trailing `_ => {}` arm.
- `variables.rs` (`(var_type, Type::NonNull(_))` arm): the original `else` returned `false`. When the new guard fails, no later arm matches a NonNull location type, so control still reaches `_ => false`.

Verified with `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --no-default-features` (494 tests pass), and `cargo fmt --check`. No behavioral change, so no changeset is included.