### PR TITLE
chore(native): upgrade oxc to 0.128

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assertables"
-version = "9.8.6"
+version = "9.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098fbfe90e8af520c4a968eaad7a4031908e473394f16c99cd9cce6369328a68"
+checksum = "627b0b35c347252505ec6c078827dfcecc4e9dcfa931c54c54066f9245ac752b"
 dependencies = [
  "regex",
  "walkdir",
@@ -101,13 +101,12 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "windows-sys",
 ]
 
@@ -137,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -222,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fnv"
@@ -240,9 +239,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -250,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
@@ -275,6 +274,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
 ]
@@ -293,9 +298,9 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -305,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.46.3"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
@@ -329,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "json-escape-simd"
@@ -347,9 +352,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libloading"
@@ -363,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -534,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "outref"
@@ -552,9 +557,9 @@ checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
 
 [[package]]
 name = "oxc-miette"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a7ba54c704edefead1f44e9ef09c43e5cfae666bdc33516b066011f0e6ebf7"
+checksum = "4356a61f2ed4c9b3610245215fbf48970eb277126919f87db9d0efa93a74245c"
 dependencies = [
  "cfg-if",
  "owo-colors",
@@ -567,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "oxc-miette-derive"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4faecb54d0971f948fbc1918df69b26007e6f279a204793669542e1e8b75eb3"
+checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -578,21 +583,21 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d4295cf7888893b80ae70ff65c078ae3f9f52d5381cfc7eeffab089e07305"
+checksum = "8b554cc48bdde5684b8a2bf3355524694ee47d9de4246eaf6199b8aecfd952cb"
 dependencies = [
  "allocator-api2",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "oxc_data_structures",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_ast"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be755331a7de00100c60e03151663f26037a0dd720be238de57c036be03b4033"
+checksum = "d027d8f8b23257e1711e0db8b80c9dacb3ab567a3357b4560eaa1d0a04da2d30"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -602,14 +607,15 @@ dependencies = [
  "oxc_estree",
  "oxc_regular_expression",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13a58adcfaadd4710b4f7d80ad422599ed5bb4956f4747d07e821c5897b16ef"
+checksum = "340ac9cb05bc9963811e3dc1585b85618471cc339d0ab0072d097dd85d78d09e"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -619,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e33ffb874949ea07fce9b686c2dba7e221c849e047232c04a84b13bae4496ef"
+checksum = "cf96f11ef5a8152aadd004616f4a91405cedab5e081f9fc816bcc02019d5f8db"
 dependencies = [
  "oxc_allocator",
  "oxc_ast",
@@ -631,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81db7038dc0288704c5ad72453c96933a46e2d5139376c87b1f5730b3d9cd03"
+checksum = "4ef50fad09eabcf3bd416036da34af8dd08979c0e9193745782c93fb7eed585f"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -646,21 +652,22 @@ dependencies = [
  "oxc_semantic",
  "oxc_sourcemap",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c22a48542899e5f74162d55710ea2f95735c5d3a809196308b2dbf557f434"
+checksum = "c425cdc1a05603d9b6d13786892d69364a0c18de06ffa511109a9e0a760b423c"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5961a78ce2a24d288f5e7090f19ce49d062486e0d65e6140d01582198c94fd"
+checksum = "fa06c0bec3b31c76e6b30b935f80dd3b29c01bf0d0fbc13b5b8f3eca508ad9ee"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -669,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fb3d121c372df31514f95d87c92693001739d2c9e56be37909499b5396faf1"
+checksum = "c675d7ad122e907016b6b7eb3e01228f313e6ff59f2a49d35d230ce214a8be9d"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -685,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38fc12975751e104dc53c369cba1598ff15aa8ca30aaac49e63937256316969"
+checksum = "0aef225084b2735b871215ceba04582ecfe15be563c4c3a9e22f33e34fab74f4"
 
 [[package]]
 name = "oxc_index"
@@ -701,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341602ba5eb6629f7f90e49c1fce06bb8eed989412a4178acd8e7f48cf2c7f9d"
+checksum = "6ad27270e0ef6b957eeda354a9a4c3ba2b42a055d4d3f2311bc72735cefaac5f"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -717,6 +724,7 @@ dependencies = [
  "oxc_ecmascript",
  "oxc_regular_expression",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "rustc-hash",
  "seq-macro",
@@ -724,15 +732,16 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e810182cbde172aeada70acc45dae74f6773384e0d295cc27e6e377b1fc277c"
+checksum = "9e92ddddf8645910675528f66b3159c018c553fa47e4644514513705f5d3c22b"
 dependencies = [
  "bitflags",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_diagnostics",
  "oxc_span",
+ "oxc_str",
  "phf",
  "rustc-hash",
  "unicode-id-start",
@@ -740,24 +749,23 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb04bd9f59bb6d8340bb186b0003bb6e8f1988e17048c61a5473ea216e9ed71"
+checksum = "498ad9075150275623586c2461461c4ef6e5e7b99ceb0665aec88574dd9b90ae"
 dependencies = [
  "itertools",
  "memchr",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
- "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "rustc-hash",
  "self_cell",
- "smallvec",
 ]
 
 [[package]]
@@ -775,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9999ef787b0b989b8c2b31669069d3bdca20d017ff34a7284ff9e983cf7b1d8"
+checksum = "f03b54ae4c2254ffdbba43f82e4ea097182b300d2f3ccd1f81f8ca145556e659"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -789,21 +797,21 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fde66bc256ea0d09895c2a56a24f79e76abffd977f6c171516e42f1efdea51"
+checksum = "686c0fe58e5a4a3698921871fbe23043ac271cf324540591dfcc5e7d0f127a5a"
 dependencies = [
  "compact_str",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "oxc_allocator",
  "oxc_estree",
 ]
 
 [[package]]
 name = "oxc_syntax"
-version = "0.115.0"
+version = "0.128.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77ea5bd4ea42ce05b2f51bcef8e46a4598cea5038ab25877a2d27601a90da83"
+checksum = "35c0e13e50d92d4c518ed2484d4c5beea46c2f3311688aaff866420abf6a73eb"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -814,6 +822,7 @@ dependencies = [
  "oxc_estree",
  "oxc_index",
  "oxc_span",
+ "oxc_str",
  "phf",
  "unicode-id-start",
 ]
@@ -826,9 +835,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.3"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e7521a040efde50c3ab6bbadafbe15ab6dc042686926be59ac35d74607df4"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -836,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.3"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187da9a3030dbafabbbfb20cb323b976dc7b7ce91fcd84f2f74d6e31d378e2de"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -846,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.3"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b401d98f5757ebe97a26085998d6c0eecec4995cad6ab7fc30ffdf4b052843"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -859,9 +868,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.3"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
@@ -931,18 +940,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "regex"
@@ -969,21 +978,21 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
@@ -1021,9 +1030,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -1098,15 +1107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -1205,9 +1205,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -1312,76 +1312,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/native/Cargo.toml
+++ b/crates/native/Cargo.toml
@@ -22,16 +22,16 @@ serde_json = "1.0"
 logos = "0.16"
 napi = { version = "3", features = ["serde-json"], optional = true }
 napi-derive = { version = "3", optional = true }
-oxc_allocator = "0.115"
-oxc_ast = "0.115"
-oxc_ast_visit = "0.115"
-oxc_codegen = "0.115"
-oxc_parser = "0.115"
-oxc_span = "0.115"
+oxc_allocator = "0.128"
+oxc_ast = "0.128"
+oxc_ast_visit = "0.128"
+oxc_codegen = "0.128"
+oxc_parser = "0.128"
+oxc_span = "0.128"
 
 [build-dependencies]
 napi-build = { version = "2", optional = true }
 
 [dev-dependencies]
-assertables = "9.8.6"
-insta = { version = "1.46", features = ["yaml", "redactions"] }
+assertables = "9.9.0"
+insta = { version = "1.47", features = ["yaml", "redactions"] }

--- a/crates/native/src/codegen/generators/module.rs
+++ b/crates/native/src/codegen/generators/module.rs
@@ -8,7 +8,7 @@ use oxc_allocator::Box as OxcBox;
 use oxc_ast::AstBuilder;
 use oxc_ast::ast::*;
 use oxc_codegen::Codegen;
-use oxc_span::{Atom, SPAN, SourceType};
+use oxc_span::{SPAN, SourceType};
 
 type StmtVec<'b> = oxc_allocator::Vec<'b, Statement<'b>>;
 
@@ -176,7 +176,7 @@ impl<'a, 'b> ModuleGenerator<'a, 'b> {
 
         let string_literal_type = self.ast.ts_type_literal_type(
             SPAN,
-            self.ast.ts_literal_string_literal(SPAN, document_source, None::<Atom>),
+            self.ast.ts_literal_string_literal(SPAN, document_source, None::<Str>),
         );
         let type_annotation = self.ast.ts_type_annotation(SPAN, string_literal_type);
 
@@ -194,7 +194,7 @@ impl<'a, 'b> ModuleGenerator<'a, 'b> {
 
         let id = self
             .ast
-            .binding_pattern_binding_identifier(SPAN, self.ast.atom("schema"));
+            .binding_pattern_binding_identifier(SPAN, self.ast.ident("schema"));
 
         let declarator = self.ast.variable_declarator(
             SPAN,
@@ -253,7 +253,7 @@ impl<'a, 'b> ModuleGenerator<'a, 'b> {
 
         let module_name = self
             .ast
-            .ts_module_declaration_name_string_literal(SPAN, name, None::<Atom>);
+            .ts_module_declaration_name_string_literal(SPAN, name, None::<Str>);
 
         let module_decl = self.ast.ts_module_declaration(
             SPAN,
@@ -307,7 +307,7 @@ impl<'a, 'b> ModuleGenerator<'a, 'b> {
 
         self.ast.ts_type_import_type(
             SPAN,
-            self.ast.string_literal(SPAN, "./types.d.ts", None::<Atom>),
+            self.ast.string_literal(SPAN, "./types.d.ts", None::<Str>),
             None::<OxcBox<ObjectExpression>>,
             Some(qualifier),
             None::<OxcBox<TSTypeParameterInstantiation>>,
@@ -329,7 +329,7 @@ impl<'a, 'b> ModuleGenerator<'a, 'b> {
     }
 
     fn create_binding_pattern(&self, name: &'b str) -> BindingPattern<'b> {
-        self.ast.binding_pattern_binding_identifier(SPAN, Atom::from(name))
+        self.ast.binding_pattern_binding_identifier(SPAN, name)
     }
 
     fn create_formal_parameter(

--- a/crates/native/src/codegen/generators/runtime.rs
+++ b/crates/native/src/codegen/generators/runtime.rs
@@ -8,7 +8,7 @@ use oxc_allocator::Box as OxcBox;
 use oxc_ast::AstBuilder;
 use oxc_ast::ast::*;
 use oxc_codegen::Codegen;
-use oxc_span::{Atom, SPAN, SourceType};
+use oxc_span::{SPAN, SourceType};
 use rustc_hash::FxHashSet;
 
 type StmtVec<'b> = oxc_allocator::Vec<'b, Statement<'b>>;
@@ -158,7 +158,7 @@ impl<'a, 'b> RuntimeGenerator<'a, 'b> {
     }
 
     fn stmt_export_const(&self, name: &str, init: Expression<'b>) -> Statement<'b> {
-        let id = self.ast.binding_pattern_binding_identifier(SPAN, self.ast.atom(name));
+        let id = self.ast.binding_pattern_binding_identifier(SPAN, self.ast.ident(name));
 
         let declarator = self.ast.variable_declarator(
             SPAN,
@@ -188,7 +188,7 @@ impl<'a, 'b> RuntimeGenerator<'a, 'b> {
 
     fn prop_object(&self, key: &str, value: Expression<'b>) -> ObjectPropertyKind<'b> {
         let property_key =
-            PropertyKey::StaticIdentifier(self.ast.alloc(self.ast.identifier_name(SPAN, self.ast.atom(key))));
+            PropertyKey::StaticIdentifier(self.ast.alloc(self.ast.identifier_name(SPAN, self.ast.ident(key))));
 
         let property = self
             .ast
@@ -202,10 +202,10 @@ impl<'a, 'b> RuntimeGenerator<'a, 'b> {
             let var_name = format!("${}", name);
             let var_ref = Expression::Identifier(
                 self.ast
-                    .alloc(self.ast.identifier_reference(SPAN, self.ast.atom(&var_name))),
+                    .alloc(self.ast.identifier_reference(SPAN, self.ast.ident(&var_name))),
             );
 
-            let string_literal = self.ast.string_literal(SPAN, self.ast.atom(source), None::<Atom>);
+            let string_literal = self.ast.string_literal(SPAN, self.ast.str(source), None::<Str>);
             let property_key = PropertyKey::StringLiteral(self.ast.alloc(string_literal));
 
             let property =
@@ -221,9 +221,7 @@ impl<'a, 'b> RuntimeGenerator<'a, 'b> {
     }
 
     fn stmt_graphql_function(&self) -> Statement<'b> {
-        let param_pattern = self
-            .ast
-            .binding_pattern_binding_identifier(SPAN, Atom::from("artifact"));
+        let param_pattern = self.ast.binding_pattern_binding_identifier(SPAN, "artifact");
         let param = self.ast.formal_parameter(
             SPAN,
             self.ast.vec(),
@@ -271,7 +269,7 @@ impl<'a, 'b> RuntimeGenerator<'a, 'b> {
         let var_declarator = self.ast.variable_declarator(
             SPAN,
             VariableDeclarationKind::Const,
-            self.ast.binding_pattern_binding_identifier(SPAN, Atom::from("graphql")),
+            self.ast.binding_pattern_binding_identifier(SPAN, "graphql"),
             None::<OxcBox<TSTypeAnnotation>>,
             Some(Expression::ArrowFunctionExpression(self.ast.alloc(arrow_function))),
             false,
@@ -323,7 +321,7 @@ impl<'a, 'b> RuntimeGenerator<'a, 'b> {
                 let entity_meta_obj =
                     Expression::ObjectExpression(self.ast.alloc(self.ast.object_expression(SPAN, entity_meta_props)));
 
-                let type_name_literal = self.ast.string_literal(SPAN, self.ast.atom(type_name), None::<Atom>);
+                let type_name_literal = self.ast.string_literal(SPAN, self.ast.str(type_name), None::<Str>);
                 let property_key = PropertyKey::StringLiteral(self.ast.alloc(type_name_literal));
 
                 let property = self.ast.object_property(
@@ -357,7 +355,7 @@ impl<'a, 'b> RuntimeGenerator<'a, 'b> {
                 let input_meta_obj =
                     Expression::ObjectExpression(self.ast.alloc(self.ast.object_expression(SPAN, input_meta_props)));
 
-                let type_name_literal = self.ast.string_literal(SPAN, self.ast.atom(type_name), None::<Atom>);
+                let type_name_literal = self.ast.string_literal(SPAN, self.ast.str(type_name), None::<Str>);
                 let property_key = PropertyKey::StringLiteral(self.ast.alloc(type_name_literal));
 
                 let property = self.ast.object_property(
@@ -392,7 +390,7 @@ impl<'a, 'b> RuntimeGenerator<'a, 'b> {
     fn expr_string(&self, value: &str) -> Expression<'b> {
         Expression::StringLiteral(
             self.ast
-                .alloc(self.ast.string_literal(SPAN, self.ast.atom(value), None::<Atom>)),
+                .alloc(self.ast.string_literal(SPAN, self.ast.str(value), None::<Str>)),
         )
     }
 
@@ -400,7 +398,7 @@ impl<'a, 'b> RuntimeGenerator<'a, 'b> {
         Expression::NumericLiteral(self.ast.alloc(self.ast.numeric_literal(
             SPAN,
             value,
-            None::<Atom>,
+            None::<Str>,
             NumberBase::Decimal,
         )))
     }

--- a/crates/native/src/codegen/generators/types.rs
+++ b/crates/native/src/codegen/generators/types.rs
@@ -9,7 +9,7 @@ use oxc_allocator::Box as OxcBox;
 use oxc_ast::AstBuilder;
 use oxc_ast::ast::*;
 use oxc_codegen::Codegen;
-use oxc_span::{Atom, SPAN, SourceType};
+use oxc_span::{SPAN, SourceType};
 use rustc_hash::FxHashMap;
 
 type StmtVec<'b> = oxc_allocator::Vec<'b, Statement<'b>>;
@@ -294,7 +294,7 @@ impl<'a, 'b> TypesGenerator<'a, 'b> {
             let field_types: Vec<TSType<'b>> = fields
                 .keys()
                 .map(|&field_name| {
-                    let string_literal = self.ast.ts_literal_string_literal(SPAN, field_name, None::<Atom>);
+                    let string_literal = self.ast.ts_literal_string_literal(SPAN, field_name, None::<Str>);
                     self.ast.ts_type_literal_type(SPAN, string_literal)
                 })
                 .collect();
@@ -311,7 +311,7 @@ impl<'a, 'b> TypesGenerator<'a, 'b> {
             let field_types: Vec<TSType<'b>> = fields
                 .keys()
                 .map(|&field_name| {
-                    let string_literal = self.ast.ts_literal_string_literal(SPAN, field_name, None::<Atom>);
+                    let string_literal = self.ast.ts_literal_string_literal(SPAN, field_name, None::<Str>);
                     self.ast.ts_type_literal_type(SPAN, string_literal)
                 })
                 .collect();
@@ -662,11 +662,11 @@ impl<'a, 'b> TypesGenerator<'a, 'b> {
     ) -> TSType<'b> {
         let mut type_params = self.ast.vec();
 
-        let kind_literal = self.ast.ts_literal_string_literal(SPAN, kind, None::<Atom>);
+        let kind_literal = self.ast.ts_literal_string_literal(SPAN, kind, None::<Str>);
         let kind_type = self.ast.ts_type_literal_type(SPAN, kind_literal);
         type_params.push(kind_type);
 
-        let name_literal = self.ast.ts_literal_string_literal(SPAN, name, None::<Atom>);
+        let name_literal = self.ast.ts_literal_string_literal(SPAN, name, None::<Str>);
         let name_type = self.ast.ts_type_literal_type(SPAN, name_literal);
         type_params.push(name_type);
 
@@ -729,8 +729,8 @@ impl<'a, 'b> TypesGenerator<'a, 'b> {
         let mut signatures = self.ast.vec();
 
         for (field_name, (field_type, is_optional)) in field_map {
-            let field_name_atom = self.ast.atom(field_name);
-            let key = self.ast.property_key_static_identifier(SPAN, field_name_atom);
+            let field_name_ident = self.ast.ident(field_name);
+            let key = self.ast.property_key_static_identifier(SPAN, field_name_ident);
             let type_annotation = self.ast.ts_type_annotation(SPAN, field_type);
 
             let sig =
@@ -746,7 +746,7 @@ impl<'a, 'b> TypesGenerator<'a, 'b> {
         let union_types: Vec<TSType<'b>> = fragment_names
             .iter()
             .map(|name| {
-                let literal = self.ast.ts_literal_string_literal(SPAN, *name, None::<Atom>);
+                let literal = self.ast.ts_literal_string_literal(SPAN, *name, None::<Str>);
                 self.ast.ts_type_literal_type(SPAN, literal)
             })
             .collect();
@@ -791,7 +791,7 @@ impl<'a, 'b> TypesGenerator<'a, 'b> {
     fn type_scalar_ref(&self, scalar_name: &'b str) -> TSType<'b> {
         let scalars = self.type_ref("$Scalars");
 
-        let string_literal = self.ast.ts_literal_string_literal(SPAN, scalar_name, None::<Atom>);
+        let string_literal = self.ast.ts_literal_string_literal(SPAN, scalar_name, None::<Str>);
         let literal_type = self.ast.ts_type_literal_type(SPAN, string_literal);
 
         self.ast.ts_type_indexed_access_type(SPAN, scalars, literal_type)
@@ -811,10 +811,10 @@ impl<'a, 'b> TypesGenerator<'a, 'b> {
     }
 
     fn stmt_export_type(&self, name: &str, ts_type: TSType<'b>) -> Statement<'b> {
-        let name_atom = self.ast.atom(name);
+        let name_ident = self.ast.ident(name);
         let decl = self.ast.ts_type_alias_declaration(
             SPAN,
-            self.ast.binding_identifier(SPAN, name_atom),
+            self.ast.binding_identifier(SPAN, name_ident),
             None::<OxcBox<TSTypeParameterDeclaration>>,
             ts_type,
             false,
@@ -840,10 +840,10 @@ impl<'a, 'b> TypesGenerator<'a, 'b> {
         for type_name in type_names {
             let local_type_name = format!("${}", type_name);
 
-            let local = self.ast.binding_identifier(SPAN, self.ast.atom(&local_type_name));
+            let local = self.ast.binding_identifier(SPAN, self.ast.ident(&local_type_name));
             let imported = self
                 .ast
-                .module_export_name_identifier_name(SPAN, self.ast.atom(type_name));
+                .module_export_name_identifier_name(SPAN, self.ast.ident(type_name));
             let specifier = self.ast.import_declaration_specifier_import_specifier(
                 SPAN,
                 imported,
@@ -856,7 +856,7 @@ impl<'a, 'b> TypesGenerator<'a, 'b> {
         let import_decl = self.ast.import_declaration(
             SPAN,
             Some(specifiers),
-            self.ast.string_literal(SPAN, "mearie/types", None::<Atom>),
+            self.ast.string_literal(SPAN, "mearie/types", None::<Str>),
             None,
             None::<OxcBox<WithClause>>,
             ImportOrExportKind::Type,


### PR DESCRIPTION
oxc 0.128 removed the Atom type from oxc_span. Identifiers and string literals are now represented by two separate types from the new oxc_str crate: Ident for identifier names and Str for string-literal values and the raw field of literal builders. Correspondingly, AstBuilder::atom() has been split into AstBuilder::ident() and AstBuilder::str(). Without adaptation the native crate fails to compile against 0.128.

This adapts the codegen generators in crates/native/src/codegen/generators/{module,runtime,types}.rs: drops the oxc_span::Atom import in favor of Str re-exported via oxc_ast::ast, replaces self.ast.atom(x) with self.ast.ident(x) where the value feeds an identifier (binding identifier, identifier name/reference, module export name, static property key) and self.ast.str(x) where it feeds a string literal value, replaces None::<Atom> with None::<Str> for the raw parameter of string_literal, ts_literal_string_literal, ts_module_declaration_name_string_literal, and numeric_literal, and replaces Atom::from(\"foo\") with the &str literal directly since Ident<'a>: From<&'a str> handles the conversion.

The Cargo.toml change also bumps assertables to 9.9.0 and insta to 1.47, which were upgraded together with oxc.

Verified with cargo build, cargo test --workspace --no-default-features (389 + 90 + 15 tests pass), cargo clippy --all-targets --no-default-features -- -D warnings, and cargo fmt --check.