### PR TITLE
Implement per-operation fetch policies

### DIFF
--- a/.changeset/per-operation-fetch-policy.md
+++ b/.changeset/per-operation-fetch-policy.md
@@ -1,0 +1,9 @@
+---
+"@mearie/core": patch
+"@mearie/react": patch
+"@mearie/solid": patch
+"@mearie/svelte": patch
+"@mearie/vue": patch
+---
+
+Implement per-operation query fetch policies. Query options now carry `fetchPolicy` into operation metadata, and `cacheExchange` respects operation-level overrides before falling back to its configured default.

--- a/packages/core/src/client.test.ts
+++ b/packages/core/src/client.test.ts
@@ -127,6 +127,65 @@ describe('Client.query()', () => {
 
     await expect(client.query(query)).rejects.toThrow(AggregatedError);
   });
+
+  it('should attach fetchPolicy to query operation metadata', async () => {
+    const operations: Operation[] = [];
+    const exchange = makeMockExchange((op) => {
+      operations.push(op);
+      return { data: { test: true } };
+    });
+
+    const client = createClient({
+      schema: testSchema,
+      exchanges: [exchange],
+    });
+
+    const query = makeArtifact('query', 'GetUser');
+
+    await client.query(query, undefined, {
+      fetchPolicy: 'network-only',
+      metadata: { traceId: 'query-1' },
+    });
+
+    expect(operations[0]!.metadata).toMatchObject({
+      traceId: 'query-1',
+      cache: { fetchPolicy: 'network-only' },
+    });
+  });
+
+  it('should attach fetchPolicy to executeQuery operation metadata', async () => {
+    const operations: Operation[] = [];
+    const exchange = makeMockExchange((op) => {
+      operations.push(op);
+      return { data: { test: true } };
+    });
+
+    const client = createClient({
+      schema: testSchema,
+      exchanges: [exchange],
+    });
+
+    const query = makeArtifact('query', 'GetUser');
+
+    let unsubscribe: (() => void) | undefined;
+    await new Promise<void>((resolve) => {
+      unsubscribe = pipe(
+        client.executeQuery(query, undefined, {
+          fetchPolicy: 'cache-and-network',
+          metadata: { traceId: 'execute-query-1' },
+        }),
+        subscribe({
+          next: () => resolve(),
+        }),
+      );
+    });
+    unsubscribe?.();
+
+    expect(operations[0]!.metadata).toMatchObject({
+      traceId: 'execute-query-1',
+      cache: { fetchPolicy: 'cache-and-network' },
+    });
+  });
 });
 
 describe('Client.mutation()', () => {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -28,10 +28,13 @@ import { collect } from './stream/sinks/collect.ts';
 import { fromAbortSignal } from './stream/sources/from-abort-signal.ts';
 import { AggregatedError } from './errors.ts';
 
+export type FetchPolicy = 'cache-first' | 'cache-and-network' | 'network-only' | 'cache-only';
+
 export type QueryOptions<T extends Artifact<'query'> = Artifact<'query'>> = {
   initialData?: DataOf<T>;
-  metadata?: OperationMetadata;
+  metadata?: OperationMetadata<T>;
   signal?: AbortSignal;
+  fetchPolicy?: FetchPolicy;
 };
 export type MutationOptions<T extends Artifact<'mutation'> = Artifact<'mutation'>> = {
   metadata?: OperationMetadata<T>;
@@ -48,6 +51,24 @@ export type ClientOptions<T extends SchemaMeta> = {
   schema: T;
   exchanges: Exchange[];
 } & (T['scalars'] extends Record<string, never> ? { scalars?: undefined } : { scalars: ScalarsConfig<T> });
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const withFetchPolicyMetadata = <T extends Artifact<'query'>>(
+  metadata: OperationMetadata<T> | undefined,
+  fetchPolicy: FetchPolicy | undefined,
+): OperationMetadata<T> | undefined => {
+  if (!fetchPolicy) return metadata;
+
+  return {
+    ...metadata,
+    cache: {
+      ...(isRecord(metadata?.cache) ? metadata.cache : {}),
+      fetchPolicy,
+    },
+  } as OperationMetadata<T>;
+};
 
 export class Client<TMeta extends SchemaMeta = SchemaMeta> {
   #schema: TMeta;
@@ -96,6 +117,18 @@ export class Client<TMeta extends SchemaMeta = SchemaMeta> {
     };
   }
 
+  private createQueryOperation<T extends Artifact<'query'>>(
+    artifact: T,
+    variables: VariablesOf<T> | undefined,
+    options: QueryOptions<T> | undefined,
+  ): Operation<'query'> {
+    return this.createOperation(
+      artifact,
+      variables,
+      withFetchPolicyMetadata(options?.metadata, options?.fetchPolicy),
+    ) as Operation<'query'>;
+  }
+
   executeOperation(operation: Operation, options?: { signal?: AbortSignal }): Source<OperationResult> {
     let source = pipe(
       this.results$,
@@ -120,7 +153,7 @@ export class Client<TMeta extends SchemaMeta = SchemaMeta> {
       ? [undefined?, QueryOptions<T>?]
       : [VariablesOf<T>, QueryOptions<T>?]
   ): Source<OperationResult> {
-    const operation = this.createOperation(artifact, variables, options?.metadata);
+    const operation = this.createQueryOperation(artifact, variables, options);
     return this.executeOperation(operation, { signal: options?.signal });
   }
 
@@ -174,7 +207,7 @@ export class Client<TMeta extends SchemaMeta = SchemaMeta> {
     const signal = options?.signal;
     signal?.throwIfAborted();
 
-    const operation = this.createOperation(artifact, variables, options?.metadata);
+    const operation = this.createQueryOperation(artifact, variables, options);
 
     let result: OperationResult;
     try {

--- a/packages/core/src/exchanges/cache.test.ts
+++ b/packages/core/src/exchanges/cache.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { cacheExchange } from './cache.ts';
 import { makeTestOperation, makeTestForward, testExchange, makeTestClient } from './test-utils.ts';
-import type { SchemaMeta, Artifact, FragmentRefs } from '@mearie/shared';
+import type { SchemaMeta, Artifact, FragmentRefs, Selection } from '@mearie/shared';
 import type { Operation, RequestOperation, Exchange, ExchangeIO, OperationResult } from '../exchange.ts';
 import { Client } from '../client.ts';
 import { pipe } from '../stream/pipe.ts';
@@ -226,6 +226,151 @@ describe('cacheExchange', () => {
 
         const results = await testExchange(exchange, forward, [operation], client);
 
+        expect(results[0]!.data).toBeNull();
+      });
+    });
+
+    describe('per-operation overrides', () => {
+      const userSelections: Selection[] = [
+        {
+          kind: 'Field',
+          name: 'user',
+          type: 'User',
+          selections: [
+            { kind: 'Field', name: '__typename', type: 'String' },
+            { kind: 'Field', name: 'id', type: 'ID' },
+            { kind: 'Field', name: 'name', type: 'String' },
+          ],
+        },
+      ];
+
+      it('should use network-only for a single operation over a cache-first default', async () => {
+        const forwardedOps: Operation[] = [];
+        let callCount = 0;
+        const exchange = cacheExchange({ fetchPolicy: 'cache-first' });
+        const forward = makeTestForward((op) => {
+          forwardedOps.push(op);
+          callCount++;
+          return {
+            operation: op,
+            data: { user: { __typename: 'User', id: '1', name: callCount === 1 ? 'Alice' : 'Bob' } },
+          };
+        });
+        const seedOperation = makeTestOperation({
+          kind: 'query',
+          name: 'PerOperationUser',
+          key: 'per-op-network-seed',
+          selections: userSelections,
+        });
+        const networkOnlyOperation = makeTestOperation({
+          kind: 'query',
+          name: 'PerOperationUser',
+          key: 'per-op-network-only',
+          selections: userSelections,
+          metadata: { cache: { fetchPolicy: 'network-only' } },
+        });
+
+        const results = await testExchange(exchange, forward, [seedOperation, networkOnlyOperation], client);
+
+        expect(forwardedOps.map((op) => op.key)).toEqual(['per-op-network-seed', 'per-op-network-only']);
+        expect(results.find((result) => result.operation.key === 'per-op-network-only')!.data).toEqual({
+          user: { __typename: 'User', id: '1', name: 'Bob' },
+        });
+      });
+
+      it('should use cache-first for a single operation over a network-only default', async () => {
+        const forwardedOps: Operation[] = [];
+        const exchange = cacheExchange({ fetchPolicy: 'network-only' });
+        const forward = makeTestForward((op) => {
+          forwardedOps.push(op);
+          return {
+            operation: op,
+            data: { user: { __typename: 'User', id: '1', name: 'Alice' } },
+          };
+        });
+        const seedOperation = makeTestOperation({
+          kind: 'query',
+          name: 'PerOperationCachedUser',
+          key: 'per-op-cache-seed',
+          selections: userSelections,
+        });
+        const cacheFirstOperation = makeTestOperation({
+          kind: 'query',
+          name: 'PerOperationCachedUser',
+          key: 'per-op-cache-first',
+          selections: userSelections,
+          metadata: { cache: { fetchPolicy: 'cache-first' } },
+        });
+
+        const results = await testExchange(exchange, forward, [seedOperation, cacheFirstOperation], client);
+
+        expect(forwardedOps.map((op) => op.key)).toEqual(['per-op-cache-seed']);
+        expect(results.find((result) => result.operation.key === 'per-op-cache-first')!.data).toEqual({
+          user: { __typename: 'User', id: '1', name: 'Alice' },
+        });
+      });
+
+      it('should use cache-and-network for a single operation over a cache-first default', async () => {
+        const forwardedOps: Operation[] = [];
+        let callCount = 0;
+        const exchange = cacheExchange({ fetchPolicy: 'cache-first' });
+        const forward = makeTestForward((op) => {
+          forwardedOps.push(op);
+          callCount++;
+          return {
+            operation: op,
+            data: { user: { __typename: 'User', id: '1', name: callCount === 1 ? 'Alice' : 'Bob' } },
+          };
+        });
+        const seedOperation = makeTestOperation({
+          kind: 'query',
+          name: 'PerOperationCacheAndNetworkUser',
+          key: 'per-op-cache-and-network-seed',
+          selections: userSelections,
+        });
+        const cacheAndNetworkOperation = makeTestOperation({
+          kind: 'query',
+          name: 'PerOperationCacheAndNetworkUser',
+          key: 'per-op-cache-and-network',
+          selections: userSelections,
+          metadata: { cache: { fetchPolicy: 'cache-and-network' } },
+        });
+
+        const results = await testExchange(exchange, forward, [seedOperation, cacheAndNetworkOperation], client);
+        const cacheAndNetworkResults = results.filter((result) => result.operation.key === 'per-op-cache-and-network');
+
+        expect(forwardedOps.map((op) => op.key)).toEqual(['per-op-cache-and-network-seed', 'per-op-cache-and-network']);
+        expect(cacheAndNetworkResults[0]!.data).toEqual({
+          user: { __typename: 'User', id: '1', name: 'Alice' },
+        });
+        expect(cacheAndNetworkResults).toContainEqual(
+          expect.objectContaining({
+            metadata: {
+              cache: {
+                patches: [{ type: 'set', path: ['user', 'name'], value: 'Bob' }],
+              },
+            },
+          }),
+        );
+      });
+
+      it('should use cache-only for a single operation over a network-only default', async () => {
+        const forwardedOps: Operation[] = [];
+        const exchange = cacheExchange({ fetchPolicy: 'network-only' });
+        const forward = makeTestForward((op) => {
+          forwardedOps.push(op);
+          return { operation: op, data: { test: true } };
+        });
+        const operation = makeTestOperation({
+          kind: 'query',
+          key: 'per-op-cache-only',
+          selections: [{ kind: 'Field', name: 'test', type: 'Boolean' }],
+          metadata: { cache: { fetchPolicy: 'cache-only' } },
+        });
+
+        const results = await testExchange(exchange, forward, [operation], client);
+
+        expect(forwardedOps).toHaveLength(0);
         expect(results[0]!.data).toBeNull();
       });
     });
@@ -1549,6 +1694,24 @@ describe('cacheExchange', () => {
 
       const sub = pipe(subject.source, result.io, subscribe({ next: (r) => results.push(r) }));
 
+      const seedOp = makeTestOperation({
+        kind: 'query',
+        name: 'StaleCacheOnlyUser',
+        key: 'stale-co-seed',
+        metadata: { cache: { fetchPolicy: 'network-only' } },
+        selections: [
+          {
+            kind: 'Field',
+            name: 'user',
+            type: 'User',
+            selections: [
+              { kind: 'Field', name: '__typename', type: 'String' },
+              { kind: 'Field', name: 'id', type: 'ID' },
+              { kind: 'Field', name: 'name', type: 'String' },
+            ],
+          },
+        ],
+      });
       const queryOp = makeTestOperation({
         kind: 'query',
         name: 'StaleCacheOnlyUser',
@@ -1566,6 +1729,14 @@ describe('cacheExchange', () => {
           },
         ],
       });
+
+      subject.next(seedOp);
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+
+      results.length = 0;
 
       subject.next(queryOp);
       await vi.runAllTimersAsync();
@@ -1592,7 +1763,7 @@ describe('cacheExchange', () => {
       expect(staleResult!.data).toEqual({ user: { __typename: 'User', id: '1', name: 'Alice' } });
 
       const networkCallsDuringInvalidation = networkCallCount - networkCountAfterInit;
-      expect(networkCallsDuringInvalidation).toBeLessThanOrEqual(1);
+      expect(networkCallsDuringInvalidation).toBe(0);
 
       sub();
       vi.useRealTimers();

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -1,5 +1,6 @@
 import type { Artifact, DataOf, SchemaMeta } from '@mearie/shared';
 import type { Exchange, RequestOperation, OperationResult } from '../exchange.ts';
+import type { FetchPolicy } from '../client.ts';
 import type { CacheNotification, CacheOperations, CacheSnapshot, InvalidateTarget, Patch } from '../cache/types.ts';
 import { Cache } from '../cache/cache.ts';
 import { pipe } from '../stream/pipe.ts';
@@ -22,6 +23,7 @@ declare module '@mearie/core' {
   interface OperationMetadataMap<T extends Artifact> {
     cache?: {
       optimisticResponse?: T extends Artifact<'mutation'> ? DataOf<T> : never;
+      fetchPolicy?: T extends Artifact<'query'> ? FetchPolicy : never;
     };
   }
   interface OperationResultMetadataMap {
@@ -30,7 +32,7 @@ declare module '@mearie/core' {
 }
 
 export type CacheOptions = {
-  fetchPolicy?: 'cache-first' | 'cache-and-network' | 'network-only' | 'cache-only';
+  fetchPolicy?: FetchPolicy;
 };
 
 export const cacheExchange = (options: CacheOptions = {}): Exchange<'cache'> => {
@@ -38,6 +40,14 @@ export const cacheExchange = (options: CacheOptions = {}): Exchange<'cache'> => 
 
   return ({ forward, client }) => {
     const cache = new Cache(client.schema);
+
+    const getOperationFetchPolicy = (op: RequestOperation): FetchPolicy => {
+      if (op.artifact.kind !== 'query') return 'network-only';
+      return op.metadata.cache?.fetchPolicy ?? fetchPolicy;
+    };
+
+    const shouldRefetchStaleQuery = (op: RequestOperation<'query'>): boolean =>
+      getOperationFetchPolicy(op) !== 'cache-only';
 
     return {
       name: 'cache',
@@ -178,7 +188,7 @@ export const cacheExchange = (options: CacheOptions = {}): Exchange<'cache'> => 
               op.variant === 'request' &&
               (op.artifact.kind === 'mutation' ||
                 op.artifact.kind === 'subscription' ||
-                (op.artifact.kind === 'query' && fetchPolicy === 'network-only')),
+                (op.artifact.kind === 'query' && getOperationFetchPolicy(op) === 'network-only')),
           ),
           tap((op) => {
             if (op.artifact.kind === 'mutation' && op.metadata?.cache?.optimisticResponse) {
@@ -191,7 +201,9 @@ export const cacheExchange = (options: CacheOptions = {}): Exchange<'cache'> => 
           ops$,
           filter(
             (op): op is RequestOperation<'query'> =>
-              op.variant === 'request' && op.artifact.kind === 'query' && fetchPolicy !== 'network-only',
+              op.variant === 'request' &&
+              op.artifact.kind === 'query' &&
+              getOperationFetchPolicy(op) !== 'network-only',
           ),
           share(),
         );
@@ -199,6 +211,7 @@ export const cacheExchange = (options: CacheOptions = {}): Exchange<'cache'> => 
         const cache$ = pipe(
           query$,
           mergeMap((op) => {
+            const operationFetchPolicy = getOperationFetchPolicy(op);
             const results = makeSubject<OperationResult>();
 
             const listener = (notification: CacheNotification) => {
@@ -220,7 +233,9 @@ export const cacheExchange = (options: CacheOptions = {}): Exchange<'cache'> => 
                       errors: [],
                     });
                   }
-                  refetch$.next(op);
+                  if (shouldRefetchStaleQuery(op)) {
+                    refetch$.next(op);
+                  }
                 }
               }
             };
@@ -241,7 +256,7 @@ export const cacheExchange = (options: CacheOptions = {}): Exchange<'cache'> => 
 
             const initial =
               data === null
-                ? fetchPolicy === 'cache-only'
+                ? operationFetchPolicy === 'cache-only'
                   ? fromValue({ operation: op, data: null, errors: [] as never })
                   : empty()
                 : fromValue({
@@ -253,22 +268,22 @@ export const cacheExchange = (options: CacheOptions = {}): Exchange<'cache'> => 
 
             const stream$ = pipe(merge(initial, results.source), takeUntil(teardown$));
 
-            if (stale) {
+            if (stale && shouldRefetchStaleQuery(op)) {
               refetch$.next(op);
             }
 
             return stream$;
           }),
-          filter(
-            () => fetchPolicy === 'cache-only' || fetchPolicy === 'cache-and-network' || fetchPolicy === 'cache-first',
-          ),
         );
 
         const network$ = pipe(
           query$,
           filter((op) => {
+            const operationFetchPolicy = getOperationFetchPolicy(op);
             const { data } = cache.readQuery(op.artifact, op.variables);
-            return fetchPolicy === 'cache-and-network' || data === null;
+            return (
+              operationFetchPolicy === 'cache-and-network' || (operationFetchPolicy === 'cache-first' && data === null)
+            );
           }),
         );
 
@@ -296,7 +311,7 @@ export const cacheExchange = (options: CacheOptions = {}): Exchange<'cache'> => 
             if (
               result.operation.variant !== 'request' ||
               result.operation.artifact.kind !== 'query' ||
-              fetchPolicy === 'network-only' ||
+              getOperationFetchPolicy(result.operation) === 'network-only' ||
               !!(result.errors && result.errors.length > 0)
             ) {
               return fromValue(result);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,6 +45,7 @@ export {
   Client,
   createClient,
   type ClientOptions,
+  type FetchPolicy,
   type QueryOptions,
   type MutationOptions,
   type SubscriptionOptions,

--- a/packages/react/src/use-query.ts
+++ b/packages/react/src/use-query.ts
@@ -83,7 +83,7 @@ export const useQuery: UseQueryFn = (<T extends Artifact<'query'>>(
   const unsubscribe = useRef<(() => void) | null>(null);
   const initialized = useRef(false);
   const stableVariables = useMemo(() => stringify(variables), [variables]);
-  const stableOptions = useMemo(() => options, [options?.skip]);
+  const stableOptions = useMemo(() => options, [options?.skip, options?.fetchPolicy]);
 
   const execute = useCallback(
     (force = false) => {

--- a/packages/svelte/src/create-query.svelte.test.ts
+++ b/packages/svelte/src/create-query.svelte.test.ts
@@ -84,6 +84,17 @@ describe('createQuery', () => {
     destroy();
   });
 
+  it('should pass fetchPolicy to executeQuery', () => {
+    const { client } = createMockClient();
+    const { destroy } = renderQuery(client, () =>
+      createQuery(mockQuery as Artifact<'query'>, undefined, () => ({ fetchPolicy: 'network-only' })),
+    );
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(client.executeQuery).toHaveBeenCalledWith(mockQuery, undefined, { fetchPolicy: 'network-only' });
+    destroy();
+  });
+
   it('should update data after initialData when fetch completes', () => {
     const { client, subjects } = createMockClient();
     const initialData = { id: '1', name: 'Prefetched' };


### PR DESCRIPTION
## Summary

- Add `QueryOptions.fetchPolicy` and carry it into query operation cache metadata for both promise and streaming query execution.
- Make `cacheExchange` prefer per-operation fetch policies before falling back to its configured default.
- Keep `cache-only` operations from forwarding cache misses or stale invalidation refetches to the network.
- Add core cache/client coverage and a Svelte wrapper regression test for passing `fetchPolicy` through.

## Validation

- `./node_modules/.bin/prettier --check packages/core/src/client.ts packages/core/src/exchanges/cache.ts packages/core/src/client.test.ts packages/core/src/exchanges/cache.test.ts packages/react/src/use-query.ts packages/svelte/src/create-query.svelte.test.ts .changeset/per-operation-fetch-policy.md`
- `./node_modules/.bin/vitest run --config packages/core/vitest.config.ts packages/core/src/client.test.ts packages/core/src/exchanges/cache.test.ts` (81 tests)
- `./node_modules/.bin/vitest run --config packages/core/vitest.config.ts packages/core/src` (1656 tests)
- `../../node_modules/.bin/vitest run --config vitest.config.ts src/create-query.svelte.test.ts` from `packages/svelte` (11 tests)
- `./node_modules/.bin/tsc -p packages/core/tsconfig.json`
- `./node_modules/.bin/tsc -p packages/svelte/tsconfig.json`
- `./node_modules/.bin/tsc -p packages/react/tsconfig.json`
- `./node_modules/.bin/tsc -p packages/vue/tsconfig.json`
- `./node_modules/.bin/tsc -p packages/solid/tsconfig.json`

## Review follow-up

A subagent review found no implementation bugs. I added the two suggested regression tests: `executeQuery` metadata propagation and per-operation `cache-and-network` override coverage.