### PR TITLE
fix(cache): notify subscribers when an entity link is replaced

### DIFF
--- a/.changeset/cache-notify-entity-link-replacement.md
+++ b/.changeset/cache-notify-entity-link-replacement.md
@@ -1,0 +1,5 @@
+---
+'@mearie/core': patch
+---
+
+Notify subscribers when a singular entity link field is replaced by a different entity. Previously, for fields with sub-selections where both the old and new values were non-null, normalize skipped the accessor callback whenever the normalized value was an entity link — so replacing the link updated storage silently: no field change was recorded, structural patches never reached subscribers, and the stale flag set by invalidate was never cleared. Arrays of links and null transitions were unaffected, which is why only singular link swaps were broken. The accessor is now always invoked for non-null nested selection writes; the equality guards in writeQuery/writeOptimistic already suppress spurious change records.

--- a/packages/core/src/cache/cache.test.ts
+++ b/packages/core/src/cache/cache.test.ts
@@ -4819,6 +4819,134 @@ describe('Cache', () => {
       unsubscribe();
     });
 
+    it('should emit patches when entity link pointer changes to different entity', () => {
+      const cache = new Cache(schema);
+      const artifact = createArtifact('query', 'GetUser', [
+        {
+          kind: 'Field',
+          name: 'user',
+          type: 'User',
+          selections: [
+            { kind: 'Field', name: '__typename', type: 'String' },
+            { kind: 'Field', name: 'id', type: 'ID' },
+            { kind: 'Field', name: 'name', type: 'String' },
+          ],
+        },
+      ]);
+      cache.writeQuery(artifact, {}, { user: { __typename: 'User', id: '1', name: 'Alice' } });
+
+      const listener = vi.fn();
+      const { unsubscribe } = cache.subscribeQuery(artifact, {}, listener);
+
+      cache.writeQuery(artifact, {}, { user: { __typename: 'User', id: '2', name: 'Bob' } });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const notification = listener.mock.calls[0]![0] as CacheNotification;
+      expect(notification.type).toBe('patch');
+      if (notification.type === 'patch') {
+        let data: unknown = { user: { __typename: 'User', id: '1', name: 'Alice' } };
+        const root = applyPatchesMutable(data, notification.patches);
+        if (root !== undefined) data = root;
+        expect(data).toEqual({ user: { __typename: 'User', id: '2', name: 'Bob' } });
+      }
+
+      unsubscribe();
+    });
+
+    it('should emit patches when a nested entity link is replaced by another entity', () => {
+      const cache = new Cache(schema);
+      const artifact = createArtifact('query', 'GetUser', [
+        {
+          kind: 'Field',
+          name: 'user',
+          type: 'User',
+          selections: [
+            { kind: 'Field', name: '__typename', type: 'String' },
+            { kind: 'Field', name: 'id', type: 'ID' },
+            {
+              kind: 'Field',
+              name: 'favoritePost',
+              type: 'Post',
+              selections: [
+                { kind: 'Field', name: '__typename', type: 'String' },
+                { kind: 'Field', name: 'id', type: 'ID' },
+                { kind: 'Field', name: 'title', type: 'String' },
+              ],
+            },
+          ],
+        },
+      ]);
+      cache.writeQuery(
+        artifact,
+        {},
+        { user: { __typename: 'User', id: '1', favoritePost: { __typename: 'Post', id: '10', title: 'Old' } } },
+      );
+
+      const listener = vi.fn();
+      const { unsubscribe } = cache.subscribeQuery(artifact, {}, listener);
+
+      cache.writeQuery(
+        artifact,
+        {},
+        { user: { __typename: 'User', id: '1', favoritePost: { __typename: 'Post', id: '20', title: 'New' } } },
+      );
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      const notification = listener.mock.calls[0]![0] as CacheNotification;
+      expect(notification.type).toBe('patch');
+      if (notification.type === 'patch') {
+        let data: unknown = {
+          user: { __typename: 'User', id: '1', favoritePost: { __typename: 'Post', id: '10', title: 'Old' } },
+        };
+        const root = applyPatchesMutable(data, notification.patches);
+        if (root !== undefined) data = root;
+        expect(data).toEqual({
+          user: { __typename: 'User', id: '1', favoritePost: { __typename: 'Post', id: '20', title: 'New' } },
+        });
+      }
+
+      unsubscribe();
+    });
+
+    it('should clear stale flag when a link field is rewritten with the same entity', () => {
+      const cache = new Cache(schema);
+      const artifact = createArtifact('query', 'GetUser', [
+        {
+          kind: 'Field',
+          name: 'user',
+          type: 'User',
+          selections: [
+            { kind: 'Field', name: '__typename', type: 'String' },
+            { kind: 'Field', name: 'id', type: 'ID' },
+            {
+              kind: 'Field',
+              name: 'favoritePost',
+              type: 'Post',
+              selections: [
+                { kind: 'Field', name: '__typename', type: 'String' },
+                { kind: 'Field', name: 'id', type: 'ID' },
+                { kind: 'Field', name: 'title', type: 'String' },
+              ],
+            },
+          ],
+        },
+      ]);
+      const data = {
+        user: { __typename: 'User', id: '1', favoritePost: { __typename: 'Post', id: '10', title: 'Old' } },
+      };
+      cache.writeQuery(artifact, {}, data);
+
+      const { subId, unsubscribe } = cache.subscribeQuery(artifact, {}, vi.fn());
+
+      cache.invalidate({ __typename: 'User', id: '1', $field: 'favoritePost' });
+      expect(cache.isStale(subId)).toBe(true);
+
+      cache.writeQuery(artifact, {}, data);
+      expect(cache.isStale(subId)).toBe(false);
+
+      unsubscribe();
+    });
+
     it('should emit patch when entity pointer changes from null to entity', () => {
       const cache = new Cache(schema);
       const artifact = createArtifact('query', 'GetUser', [

--- a/packages/core/src/cache/normalize.ts
+++ b/packages/core/src/cache/normalize.ts
@@ -125,14 +125,7 @@ export const normalize = (
           : fieldValue;
         fields[fieldKey] = normalized;
 
-        if (
-          storageKey !== null &&
-          selection.selections &&
-          !isNullish(oldValue) &&
-          !isNullish(fieldValue) &&
-          !isEntityLink(fields[fieldKey]) &&
-          !isEqual(oldValue, fields[fieldKey])
-        ) {
+        if (storageKey !== null && selection.selections && !isNullish(oldValue) && !isNullish(fieldValue)) {
           callAccessor?.(storageKey, fieldKey, oldValue, fields[fieldKey]);
         }
       } else if (selection.kind === 'FragmentSpread' || inlineFragmentMatches(selection, typename)) {

--- a/packages/core/src/exchanges/cache.test.ts
+++ b/packages/core/src/exchanges/cache.test.ts
@@ -17,6 +17,7 @@ import { mergeMap } from '../stream/operators/merge-map.ts';
 import { fromPromise } from '../stream/sources/from-promise.ts';
 import type { Source } from '../stream/types.ts';
 import { fromValue } from '../stream/index.ts';
+import { applyPatchesMutable } from '../cache/patch.ts';
 
 const schema: SchemaMeta = {
   entities: {
@@ -1367,6 +1368,99 @@ describe('cacheExchange', () => {
       await vi.runAllTimersAsync();
 
       expect(callCount).toBe(2);
+
+      sub();
+      vi.useRealTimers();
+    });
+
+    it('should deliver refetched data when $field invalidation replaces an entity link', async () => {
+      vi.useFakeTimers();
+
+      let callCount = 0;
+      const exchange = cacheExchange({ fetchPolicy: 'cache-and-network' });
+      const forward: ExchangeIO = (ops$) =>
+        pipe(
+          ops$,
+          filter((op) => op.variant === 'request'),
+          map((op) => {
+            callCount++;
+            return {
+              operation: op,
+              data: {
+                user: {
+                  __typename: 'User',
+                  id: '1',
+                  favoritePost:
+                    callCount === 1
+                      ? { __typename: 'Post', id: '10', title: 'Old' }
+                      : { __typename: 'Post', id: '20', title: 'New' },
+                },
+              },
+            } as OperationResult;
+          }),
+        );
+
+      const subject = makeSubject<Operation>();
+      const result = exchange({ forward, client: client as never });
+      const results: OperationResult[] = [];
+
+      const sub = pipe(subject.source, result.io, subscribe({ next: (r) => results.push(r) }));
+
+      const queryOp = makeTestOperation({
+        kind: 'query',
+        name: 'GetUserFavoritePost',
+        key: 'q1',
+        selections: [
+          {
+            kind: 'Field',
+            name: 'user',
+            type: 'User',
+            selections: [
+              { kind: 'Field', name: '__typename', type: 'String' },
+              { kind: 'Field', name: 'id', type: 'ID' },
+              {
+                kind: 'Field',
+                name: 'favoritePost',
+                type: 'Post',
+                selections: [
+                  { kind: 'Field', name: '__typename', type: 'String' },
+                  { kind: 'Field', name: 'id', type: 'ID' },
+                  { kind: 'Field', name: 'title', type: 'String' },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      subject.next(queryOp);
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+
+      expect(callCount).toBe(1);
+
+      result.extension.invalidate({ __typename: 'User', id: '1', $field: 'favoritePost' });
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+      await vi.runAllTimersAsync();
+
+      expect(callCount).toBe(2);
+
+      let data: unknown;
+      for (const r of results) {
+        const patches = r.metadata?.cache?.patches;
+        if (patches) {
+          const root = applyPatchesMutable(data, patches);
+          if (root !== undefined) data = root;
+        } else if (r.data !== undefined) {
+          data = r.data;
+        }
+      }
+      expect((data as { user: { favoritePost: unknown } }).user.favoritePost).toEqual({
+        __typename: 'Post',
+        id: '20',
+        title: 'New',
+      });
 
       sub();
       vi.useRealTimers();


### PR DESCRIPTION
Replacing a singular entity link with a different entity (e.g. a `user.nextSubscription` field pointing to a newly created subscription row after a plan change) updated cache storage but never notified subscribers. Query and fragment subscriptions kept rendering the old entity until a full reload, and the stale flag set by `invalidate` was never cleared, leaving the subscription permanently stale.

The cause is in `normalize`: for fields with sub-selections where both the previous and incoming values are non-null, the accessor callback was only invoked when the normalized value was not an entity link (`!isEntityLink(fields[fieldKey])`). A non-null link → different non-null link transition therefore never produced a `FieldChange`, so `processStructuralChanges` never re-traced affected subscriptions, and the stale bookkeeping in `writeQuery` (which lives in the same accessor) was skipped as well. Arrays of links pass that guard (an array is not an entity link) and `null` transitions are reported by the earlier branch, which is why list fields and `null` ↔ link swaps behaved correctly and only singular link replacement was silent. The existing "entity pointer swap" tests only asserted storage contents, not subscriber notification.

The fix always invokes the accessor for non-null nested selection writes and relies on the existing `isEqual` guards in `writeQuery`/`writeOptimistic` to suppress spurious change records. This delivers structural patches on link replacement and also restores stale clearing when a link field is rewritten with the same entity.
