### PR TITLE
fix(cache): refetch stale queries even when cache is partial

### DIFF
--- a/.changeset/cache-refetch-stale-partial-query.md
+++ b/.changeset/cache-refetch-stale-partial-query.md
@@ -1,0 +1,5 @@
+---
+'@mearie/core': patch
+---
+
+Refetch stale queries after invalidation even when the cached query is partial. The cache exchange decided whether to refetch by re-reading the query and checking the derived stale flag, but readQuery returns { data: null, stale: false } for partial results — so once a subscribed query became unreadable from cache (e.g. a link was rewritten to an entity with fewer cached fields), invalidate could never trigger a refetch, which is exactly when the network is needed most. The stale notification listener now consults the subscription's own stale flag via cache.isStale and refetches regardless of readability, emitting the cached data alongside only when it is still complete.

--- a/packages/core/src/exchanges/cache.test.ts
+++ b/packages/core/src/exchanges/cache.test.ts
@@ -1611,6 +1611,122 @@ describe('cacheExchange', () => {
       vi.useRealTimers();
     });
 
+    it('should refetch stale query after $field invalidation even when the cached query is partial', async () => {
+      vi.useFakeTimers();
+
+      let fullCallCount = 0;
+      const exchange = cacheExchange({ fetchPolicy: 'cache-and-network' });
+      const forward: ExchangeIO = (ops$) =>
+        pipe(
+          ops$,
+          filter((op): op is RequestOperation => op.variant === 'request'),
+          map((op) => {
+            if (op.artifact.name === 'GetUserFavoritePostPartial') {
+              fullCallCount++;
+              return {
+                operation: op,
+                data: {
+                  user: {
+                    __typename: 'User',
+                    id: '1',
+                    favoritePost: { __typename: 'Post', id: '10', title: 'Old' },
+                  },
+                },
+              } as OperationResult;
+            }
+            return {
+              operation: op,
+              data: { user: { __typename: 'User', id: '1', favoritePost: { __typename: 'Post', id: '20' } } },
+            } as OperationResult;
+          }),
+        );
+
+      const subject = makeSubject<Operation>();
+      const result = exchange({ forward, client: client as never });
+      const results: OperationResult[] = [];
+
+      const sub = pipe(subject.source, result.io, subscribe({ next: (r) => results.push(r) }));
+
+      const fullOp = makeTestOperation({
+        kind: 'query',
+        name: 'GetUserFavoritePostPartial',
+        key: 'q1',
+        selections: [
+          {
+            kind: 'Field',
+            name: 'user',
+            type: 'User',
+            selections: [
+              { kind: 'Field', name: '__typename', type: 'String' },
+              { kind: 'Field', name: 'id', type: 'ID' },
+              {
+                kind: 'Field',
+                name: 'favoritePost',
+                type: 'Post',
+                selections: [
+                  { kind: 'Field', name: '__typename', type: 'String' },
+                  { kind: 'Field', name: 'id', type: 'ID' },
+                  { kind: 'Field', name: 'title', type: 'String' },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      const sparseOp = makeTestOperation({
+        kind: 'query',
+        name: 'GetUserFavoritePostId',
+        key: 'q2',
+        selections: [
+          {
+            kind: 'Field',
+            name: 'user',
+            type: 'User',
+            selections: [
+              { kind: 'Field', name: '__typename', type: 'String' },
+              { kind: 'Field', name: 'id', type: 'ID' },
+              {
+                kind: 'Field',
+                name: 'favoritePost',
+                type: 'Post',
+                selections: [
+                  { kind: 'Field', name: '__typename', type: 'String' },
+                  { kind: 'Field', name: 'id', type: 'ID' },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      subject.next(fullOp);
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+
+      expect(fullCallCount).toBe(1);
+
+      // The sparse query relinks user.favoritePost to Post:20, which lacks
+      // title — the full query can no longer be read from cache.
+      subject.next(sparseOp);
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+
+      expect(results.filter((r) => r.operation.key === 'q1').every((r) => !r.errors || r.errors.length === 0)).toBe(
+        true,
+      );
+
+      result.extension.invalidate({ __typename: 'User', id: '1', $field: 'favoritePost' });
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+      await vi.runAllTimersAsync();
+
+      expect(fullCallCount).toBe(2);
+
+      sub();
+      vi.useRealTimers();
+    });
+
     it('should refetch query after $field invalidation when field is inside a fragment spread', async () => {
       vi.useFakeTimers();
 

--- a/packages/core/src/exchanges/cache.ts
+++ b/packages/core/src/exchanges/cache.ts
@@ -213,6 +213,7 @@ export const cacheExchange = (options: CacheOptions = {}): Exchange<'cache'> => 
           mergeMap((op) => {
             const operationFetchPolicy = getOperationFetchPolicy(op);
             const results = makeSubject<OperationResult>();
+            let subId = -1;
 
             const listener = (notification: CacheNotification) => {
               if (notification.type === 'patch') {
@@ -223,24 +224,24 @@ export const cacheExchange = (options: CacheOptions = {}): Exchange<'cache'> => 
                   errors: [],
                 });
               } else {
-                const { data: staleData, stale: isStale } = cache.readQuery(op.artifact, op.variables);
-                if (isStale) {
-                  if (staleData !== null) {
-                    results.next({
-                      operation: op,
-                      data: staleData,
-                      metadata: { cache: { stale: true } },
-                      errors: [],
-                    });
-                  }
-                  if (shouldRefetchStaleQuery(op)) {
-                    refetch$.next(op);
-                  }
+                if (!cache.isStale(subId)) return;
+                const { data: staleData } = cache.readQuery(op.artifact, op.variables);
+                if (staleData !== null) {
+                  results.next({
+                    operation: op,
+                    data: staleData,
+                    metadata: { cache: { stale: true } },
+                    errors: [],
+                  });
+                }
+                if (shouldRefetchStaleQuery(op)) {
+                  refetch$.next(op);
                 }
               }
             };
 
-            const { data, stale, unsubscribe } = cache.subscribeQuery(op.artifact, op.variables, listener);
+            const { data, stale, subId: id, unsubscribe } = cache.subscribeQuery(op.artifact, op.variables, listener);
+            subId = id;
 
             subscriptionHasData.set(op.key, data !== null);
 


### PR DESCRIPTION
When a subscribed query could not be fully read from cache, `invalidate` silently stopped triggering refetches for it. The stale notification listener in `cacheExchange` decided whether to refetch by re-reading the query and checking the derived stale flag, but `readQuery` returns `{ data: null, stale: false }` for partial results. So once a query became unreadable from cache — for example after a link field was rewritten by another operation to an entity that has fewer cached fields — invalidation was swallowed and the subscription could never recover through the cache exchange, even though a network round-trip is exactly what a partial query needs.

The listener now consults the subscription's own stale flag via `cache.isStale(subId)`, which is maintained by `invalidate` and the stale-clear bookkeeping independently of cache readability. When the subscription is stale it always forwards a refetch; the cached snapshot is emitted alongside only when it is still complete.
