### PR TITLE
fix(cache): refresh stalled subscription cursors on incomplete re-trace

### DIFF
--- a/.changeset/cache-refresh-stalled-cursors.md
+++ b/.changeset/cache-refresh-stalled-cursors.md
@@ -1,0 +1,5 @@
+---
+'@mearie/core': patch
+---
+
+Re-register subscription cursors when a stalled (partially cached) query is re-traced after a write that still leaves it incomplete. Previously only the complete branch of the stalled-subscription check refreshed the cursor registry — the structural-change path already refreshes unconditionally — so a subscription that started out partial kept its initial shallow cursors. Dependencies on deeper fields were invisible to invalidate, and the stale notification never reached the subscription until it happened to become complete.

--- a/packages/core/src/cache/cache.test.ts
+++ b/packages/core/src/cache/cache.test.ts
@@ -4988,6 +4988,39 @@ describe('Cache', () => {
     });
   });
 
+  describe('stalled subscription cursor refresh', () => {
+    it('should keep invalidate reachable while a subscription stays partially filled', () => {
+      const cache = new Cache(schema);
+      const artifact = createArtifact('query', 'GetUser', [
+        {
+          kind: 'Field',
+          name: 'user',
+          type: 'User',
+          selections: [
+            { kind: 'Field', name: '__typename', type: 'String' },
+            { kind: 'Field', name: 'id', type: 'ID' },
+            { kind: 'Field', name: 'name', type: 'String' },
+            { kind: 'Field', name: 'email', type: 'String' },
+          ],
+        },
+      ]);
+
+      const listener = vi.fn();
+      const { subId, unsubscribe } = cache.subscribeQuery(artifact, {}, listener);
+
+      // email is still missing after this write, so the subscription stays stalled
+      cache.writeQuery(artifact, {}, { user: { __typename: 'User', id: '1', name: 'Alice' } });
+      listener.mockClear();
+
+      cache.invalidate({ __typename: 'User', id: '1', $field: 'name' });
+
+      expect(cache.isStale(subId)).toBe(true);
+      expect(listener).toHaveBeenCalledWith({ type: 'stale' });
+
+      unsubscribe();
+    });
+  });
+
   describe('subscribeFragment incomplete trace not stalled', () => {
     it('should not be called when missing fields are filled because fragment does not use stalled tracking', () => {
       const cache = new Cache(schema);

--- a/packages/core/src/cache/cache.ts
+++ b/packages/core/src/cache/cache.ts
@@ -614,12 +614,13 @@ export class Cache {
         sub.id,
       );
 
+      this.#registry.removeAll(sub.cursors);
+      sub.cursors = new Set(traceResult.cursors.map((c) => c.entry));
+      for (const { depKey, entry } of traceResult.cursors) {
+        this.#registry.add(depKey, entry);
+      }
+
       if (traceResult.complete) {
-        this.#registry.removeAll(sub.cursors);
-        sub.cursors = new Set(traceResult.cursors.map((c) => c.entry));
-        for (const { depKey, entry } of traceResult.cursors) {
-          this.#registry.add(depKey, entry);
-        }
         this.#stalled.delete(subId);
 
         const entityArrayChanges = buildEntityArrayContext(changes, traceResult.cursors);


### PR DESCRIPTION
A subscription that starts out partially cached registers only shallow cursors — `traceSelections` cannot walk past a missing field, so the initial trace of an empty or incomplete cache stops at the first hole (e.g. only `__root.user@{}` for a nested query). The stalled-subscription machinery (`#stalled` / `missingDeps`) is designed to carry such subscriptions until writes fill the gaps, but `#checkStalled` only refreshed the cursor registry in its complete branch. While the subscription stayed incomplete across partial writes, its cursors remained shallow: dependencies on deeper fields (`User:1.name@{}` etc.) were never registered, so `invalidate` could not collect the subscription and the stale notification never reached it. This sits one step upstream of the fix in #152 — there the listener swallowed the notification; here the notification is never delivered at all.

The sibling path for the same situation is already defensive: `processStructuralChanges` re-registers cursors unconditionally, whether or not the re-trace is complete. The fix aligns `#checkStalled` with that pattern by hoisting the `removeAll`/re-register step above the completeness check, so cursor reachability improves with every partial fill. Healing behavior is unchanged — completion detection still goes through `missingDeps`, and the complete branch still delivers the unstalled diff.
